### PR TITLE
fix: relative import error, add lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ Thumbs.db
 
 # Build artifacts
 *.wasm
+
+# Lock files
+pyproject.toml.lock
+uv.lock

--- a/src/handlers/contributors.py
+++ b/src/handlers/contributors.py
@@ -3,8 +3,8 @@ Contributors handler for the BLT API.
 """
 
 from typing import Any, Dict
-from ..utils import json_response, error_response, paginated_response, parse_pagination_params
-from ..client import create_client
+from utils import json_response, error_response, paginated_response, parse_pagination_params
+from client import create_client
 
 
 async def handle_contributors(

--- a/src/handlers/domains.py
+++ b/src/handlers/domains.py
@@ -3,8 +3,8 @@ Domains handler for the BLT API.
 """
 
 from typing import Any, Dict
-from ..utils import json_response, error_response, paginated_response, parse_pagination_params
-from ..client import create_client
+from utils import json_response, error_response, paginated_response, parse_pagination_params
+from client import create_client
 
 
 async def handle_domains(

--- a/src/handlers/health.py
+++ b/src/handlers/health.py
@@ -3,7 +3,7 @@ Health check handler.
 """
 
 from typing import Any, Dict
-from ..utils import json_response
+from utils import json_response
 
 
 async def handle_health(

--- a/src/handlers/hunts.py
+++ b/src/handlers/hunts.py
@@ -3,8 +3,8 @@ Bug Hunts handler for the BLT API.
 """
 
 from typing import Any, Dict
-from ..utils import json_response, error_response, paginated_response, parse_pagination_params
-from ..client import create_client
+from utils import json_response, error_response, paginated_response, parse_pagination_params
+from client import create_client
 
 
 async def handle_hunts(

--- a/src/handlers/issues.py
+++ b/src/handlers/issues.py
@@ -3,8 +3,8 @@ Issues handler for the BLT API.
 """
 
 from typing import Any, Dict
-from ..utils import json_response, error_response, paginated_response, parse_pagination_params, parse_json_body
-from ..client import create_client
+from utils import json_response, error_response, paginated_response, parse_pagination_params, parse_json_body
+from client import create_client
 
 
 async def handle_issues(

--- a/src/handlers/leaderboard.py
+++ b/src/handlers/leaderboard.py
@@ -3,8 +3,8 @@ Leaderboard handler for the BLT API.
 """
 
 from typing import Any, Dict
-from ..utils import json_response, error_response, paginated_response, parse_pagination_params
-from ..client import create_client
+from utils import json_response, error_response, paginated_response, parse_pagination_params
+from client import create_client
 
 
 async def handle_leaderboard(

--- a/src/handlers/organizations.py
+++ b/src/handlers/organizations.py
@@ -3,8 +3,8 @@ Organizations handler for the BLT API.
 """
 
 from typing import Any, Dict
-from ..utils import json_response, error_response, paginated_response, parse_pagination_params
-from ..client import create_client
+from utils import json_response, error_response, paginated_response, parse_pagination_params
+from client import create_client
 
 
 async def handle_organizations(

--- a/src/handlers/projects.py
+++ b/src/handlers/projects.py
@@ -3,8 +3,8 @@ Projects handler for the BLT API.
 """
 
 from typing import Any, Dict
-from ..utils import json_response, error_response, paginated_response, parse_pagination_params
-from ..client import create_client
+from utils import json_response, error_response, paginated_response, parse_pagination_params
+from client import create_client
 
 
 async def handle_projects(

--- a/src/handlers/repos.py
+++ b/src/handlers/repos.py
@@ -3,8 +3,8 @@ Repositories handler for the BLT API.
 """
 
 from typing import Any, Dict
-from ..utils import json_response, error_response, paginated_response, parse_pagination_params
-from ..client import create_client
+from utils import json_response, error_response, paginated_response, parse_pagination_params
+from client import create_client
 
 
 async def handle_repos(

--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -3,8 +3,8 @@ Stats handler for the BLT API.
 """
 
 from typing import Any, Dict
-from ..utils import json_response, error_response
-from ..client import create_client
+from utils import json_response, error_response
+from client import create_client
 
 
 async def handle_stats(

--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -3,8 +3,8 @@ Users handler for the BLT API.
 """
 
 from typing import Any, Dict
-from ..utils import json_response, error_response, paginated_response, parse_pagination_params
-from ..client import create_client
+from utils import json_response, error_response, paginated_response, parse_pagination_params
+from client import create_client
 
 
 async def handle_users(

--- a/src/main.py
+++ b/src/main.py
@@ -11,10 +11,10 @@ try:
     _WORKERS_RUNTIME = True
 except ImportError:
     _WORKERS_RUNTIME = False
-    from .utils import Response, Headers
+    from utils import Response, Headers
 
-from .router import Router
-from .handlers import (
+from router import Router
+from handlers import (
     handle_issues,
     handle_users,
     handle_domains,
@@ -27,7 +27,7 @@ from .handlers import (
     handle_repos,
     handle_health,
 )
-from .utils import json_response, error_response, cors_headers
+from utils import json_response, error_response, cors_headers
 
 
 # Initialize the router

--- a/src/router.py
+++ b/src/router.py
@@ -7,7 +7,7 @@ path parameters and different HTTP methods.
 
 import re
 from typing import Callable, Dict, List, Optional, Tuple, Any
-from .utils import error_response, json_response
+from utils import error_response, json_response
 
 
 class Route:

--- a/src/utils.py
+++ b/src/utils.py
@@ -77,7 +77,8 @@ def json_response(
     json_body = json.dumps(data)
     
     # Create headers object for JavaScript
-    js_headers = Headers.new(response_headers)
+    # Convert dict to list of tuples for Headers.new (expects Sequence)
+    js_headers = Headers.new(list(response_headers.items()))
     
     return Response.new(json_body, status=status, headers=js_headers)
 


### PR DESCRIPTION
## **PR Description**

fixes: #3 

Fix import errors in the Python worker by replacing relative imports with absolute imports.
This makes the BLT API worker compatible with the edge/pyodide runtime and avoids package-context issues during startup.


<img width="658" height="592" alt="2026-01-13_00-17-29" src="https://github.com/user-attachments/assets/e095bf6d-183f-4fd9-88f2-7c376ebcf08f" />
