### PR TITLE
refactor+fix: extract email templates into separate HTML files and fix signup 

### DIFF
--- a/src/handlers/auth.py
+++ b/src/handlers/auth.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 
 from libs.db import get_db_safe
 from utils import parse_json_body, error_response, cors_headers, check_required_fields, json_response, convert_single_d1_result, extract_id_from_result
-from libs.constant import __HASHING_ITERATIONS, __HASHING_ALGORITHM
+from libs.constant import __HASHING_ITERATIONS
 from libs.jwt_utils import create_access_token, decode_jwt
 from services.email_service import EmailService
 
@@ -63,7 +63,7 @@ async def handle_signup(
 
         # Hash the password using PBKDF2
         salt = secrets.token_hex(16)
-        password_hash = hashlib.pbkdf2_hmac(__HASHING_ALGORITHM, body["password"].encode('utf-8'), salt.encode('utf-8'), __HASHING_ITERATIONS)
+        password_hash = hashlib.pbkdf2_hmac('sha256', body["password"].encode('utf-8'), salt.encode('utf-8'), __HASHING_ITERATIONS)
         hashed_password = f"{salt}${password_hash.hex()}"
 
         # Insert the new user into the database

--- a/src/services/email_templates.py
+++ b/src/services/email_templates.py
@@ -1,253 +1,85 @@
-"""HTML email templates for BLT API.
+"""HTML email templates loader for BLT API.
 
-Professional, responsive email templates aligned with BLT branding.
+Clean separation of templates and code - templates are stored as external HTML files.
 """
 
+from pathlib import Path
 from html import escape
+import os
 
 
-def _e(value: str) -> str:
-    """Escape dynamic content inserted into HTML templates."""
+# Get the templates directory path
+TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+
+def _e(value) -> str:
+    """Escape dynamic content for safe insertion into HTML templates."""
     return escape(str(value), quote=True)
 
 
-def get_base_template(content: str, title: str = "OWASP BLT") -> str:
-    """Base email template with consistent styling.
-
-    Args:
-        content: HTML content to insert into the body.
-        title: Email title.
-
-    Returns:
-        Complete HTML email string.
+def load_template(template_name: str, safe_vars: list = None, **kwargs) -> str:
     """
-    safe_title = _e(title)
+    Load an HTML template file and replace placeholders with provided values.
+    
+    Placeholders use [[variable]] syntax to avoid conflicts with CSS braces.
+    
+    Args:
+        template_name: Name of the template file (e.g., 'verification.html')
+        safe_vars: List of variable names that should NOT be HTML-escaped (e.g., ['content'])
+        **kwargs: Key-value pairs to replace in the template
+    
+    Returns:
+        Rendered HTML string with placeholders replaced
+    
+    Example:
+        >>> load_template('verification.html', username='john', verification_link='https://...')
+    """
+    template_path = TEMPLATES_DIR / template_name
+    
+    # Read template file
+    try:
+        with open(template_path, 'r', encoding='utf-8') as f:
+            template = f.read()
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Template not found: {template_path}")
+    except Exception as e:
+        raise Exception(f"Error loading template {template_name}: {str(e)}")
+    
+    safe_vars = safe_vars or []
+    
+    # Replace placeholders with actual values
+    # Using [[variable]] syntax to avoid conflicts with CSS {braces}
+    for key, value in kwargs.items():
+        placeholder = f"[[{key}]]"
+        # Don't escape values that are already safe HTML (like 'content')
+        if key in safe_vars:
+            safe_value = str(value)
+        else:
+            safe_value = _e(value)
+        template = template.replace(placeholder, safe_value)
+    
+    # Check for any unreplaced placeholders (helps catch errors)
+    import re
+    unreplaced = re.findall(r'\[\[(\w+)\]\]', template)
+    if unreplaced:
+        raise KeyError(f"Missing required template variables: {', '.join(unreplaced)}")
+    
+    return template
 
-    return f"""
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{safe_title}</title>
-    <style>
-        body {{
-            margin: 0;
-            padding: 0;
-            width: 100% !important;
-            background-color: #f5f5f5;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            color: #1f2937;
-            line-height: 1.6;
-        }}
-        table {{
-            border-spacing: 0;
-            border-collapse: collapse;
-        }}
-        .wrapper {{
-            width: 100%;
-            background-color: #f5f5f5;
-            padding: 24px 12px;
-        }}
-        .container {{
-            width: 100%;
-            max-width: 640px;
-            margin: 0 auto;
-            background: #ffffff;
-            border: 1px solid #e5e5e5;
-            border-radius: 12px;
-            overflow: hidden;
-        }}
-        .header {{
-            background-color: #111827;
-            border-bottom: 4px solid #e10101;
-            padding: 28px 28px 22px;
-            text-align: center;
-        }}
-        .header h1 {{
-            margin: 0;
-            color: #ffffff;
-            font-size: 26px;
-            font-weight: 700;
-            letter-spacing: 0.3px;
-        }}
-        .header p {{
-            margin: 6px 0 0;
-            color: #d1d5db;
-            font-size: 13px;
-        }}
-        .content {{
-            padding: 30px 28px 12px;
-        }}
-        .content h2 {{
-            margin: 0 0 14px;
-            font-size: 24px;
-            line-height: 1.3;
-            color: #111827;
-            font-weight: 700;
-        }}
-        .content h3 {{
-            margin: 24px 0 10px;
-            font-size: 18px;
-            line-height: 1.4;
-            color: #111827;
-            font-weight: 700;
-        }}
-        .content p {{
-            margin: 0 0 14px;
-            color: #374151;
-            font-size: 15px;
-        }}
-        .content a {{
-            color: #e10101;
-            text-decoration: none;
-        }}
-        .content a:hover {{
-            text-decoration: underline;
-        }}
-        .button-wrap {{
-            text-align: center;
-            padding: 8px 0 10px;
-        }}
-        .button {{
-            display: inline-block;
-            background-color: #e10101;
-            color: #ffffff !important;
-            text-decoration: none;
-            font-size: 15px;
-            font-weight: 700;
-            padding: 12px 24px;
-            border-radius: 8px;
-            border: 1px solid #e10101;
-        }}
-        .button:hover {{
-            background-color: #b91c1c;
-            border-color: #b91c1c;
-            text-decoration: none;
-        }}
-        .link-box {{
-            margin: 16px 0 22px;
-            padding: 12px 14px;
-            border: 1px solid #e5e5e5;
-            border-radius: 8px;
-            background-color: #fafafa;
-            color: #111827;
-            font-size: 13px;
-            word-break: break-all;
-        }}
-        .info-box {{
-            margin: 16px 0;
-            padding: 12px 14px;
-            background-color: #fef2f2;
-            border-left: 4px solid #e10101;
-            border-radius: 6px;
-        }}
-        .info-box p {{
-            margin: 0;
-            color: #7f1d1d;
-            font-size: 14px;
-        }}
-        .divider {{
-            height: 1px;
-            background-color: #e5e5e5;
-            margin: 22px 0;
-        }}
-        ul, ol {{
-            margin: 8px 0 16px;
-            padding-left: 20px;
-            color: #374151;
-            font-size: 15px;
-        }}
-        li {{
-            margin: 7px 0;
-        }}
-        .footer {{
-            padding: 20px 28px 28px;
-            border-top: 1px solid #e5e5e5;
-            background-color: #fafafa;
-            text-align: center;
-        }}
-        .footer p {{
-            margin: 0 0 8px;
-            color: #6b7280;
-            font-size: 13px;
-        }}
-        .footer a {{
-            color: #e10101;
-            text-decoration: none;
-            font-weight: 600;
-        }}
-        .muted {{
-            color: #6b7280;
-            font-size: 13px;
-        }}
-        .small {{
-            font-size: 12px;
-            color: #9ca3af;
-        }}
-        @media only screen and (max-width: 640px) {{
-            .wrapper {{
-                padding: 12px 0;
-            }}
-            .container {{
-                border-radius: 0;
-                border-left: none;
-                border-right: none;
-            }}
-            .header,
-            .content,
-            .footer {{
-                padding-left: 18px;
-                padding-right: 18px;
-            }}
-            .content h2 {{
-                font-size: 22px;
-            }}
-        }}
-    </style>
-</head>
-<body>
-    <span style="display:none !important; visibility:hidden; opacity:0; color:transparent; height:0; width:0; overflow:hidden;">
-        {safe_title}
-    </span>
 
-    <table role="presentation" width="100%" class="wrapper">
-        <tr>
-            <td align="center">
-                <table role="presentation" width="100%" class="container">
-                    <tr>
-                        <td class="header">
-                            <h1>OWASP BLT</h1>
-                            <p>Bug Logging Tool</p>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="content">
-                            {content}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="footer">
-                            <p><strong>OWASP Bug Logging Tool</strong></p>
-                            <p>Making the web more secure, one report at a time.</p>
-                            <p>
-                                <a href="https://owaspblt.org">Website</a>
-                                &nbsp;|&nbsp;
-                                <a href="https://github.com/OWASP-BLT">GitHub</a>
-                                &nbsp;|&nbsp;
-                                <a href="https://owasp.org">OWASP</a>
-                            </p>
-                            <p class="small">This is an automated message. Please do not reply to this email.</p>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-</body>
-</html>
-"""
+def render_in_base(content: str, title: str = "OWASP BLT") -> str:
+    """
+    Wrap content in the base email template layout.
+    
+    Args:
+        content: HTML content to insert into the body (already safe HTML)
+        title: Email page title
+    
+    Returns:
+        Complete HTML email with base layout
+    """
+    # 'content' is safe HTML we generated, don't escape it
+    return load_template('base.html', safe_vars=['content'], content=content, title=title)
 
 
 def get_verification_email(username: str, verification_link: str, expires_hours: int = 24) -> str:
@@ -261,30 +93,13 @@ def get_verification_email(username: str, verification_link: str, expires_hours:
     Returns:
         HTML email content.
     """
-    safe_username = _e(username)
-    safe_verification_link = _e(verification_link)
-
-    content = f"""
-        <h2>Verify your email address</h2>
-        <p>Hello <strong>{safe_username}</strong>,</p>
-        <p>Thanks for registering with OWASP BLT. Confirm your email address to activate your account.</p>
-
-        <div class="button-wrap">
-            <a href="{safe_verification_link}" class="button">Verify Email</a>
-        </div>
-
-        <div class="info-box">
-            <p><strong>Important:</strong> This verification link expires in {expires_hours} hours.</p>
-        </div>
-
-        <p class="muted">If the button does not work, copy and paste this link into your browser:</p>
-        <div class="link-box">{safe_verification_link}</div>
-
-        <div class="divider"></div>
-
-        <p class="muted">If you did not create an OWASP BLT account, you can safely ignore this email.</p>
-    """
-    return get_base_template(content, "Verify Your Email - OWASP BLT")
+    content = load_template(
+        'verification.html',
+        username=username,
+        verification_link=verification_link,
+        expires_hours=expires_hours
+    )
+    return render_in_base(content, "Verify Your Email - OWASP BLT")
 
 
 def get_password_reset_email(username: str, reset_link: str, expires_hours: int = 1) -> str:
@@ -298,32 +113,13 @@ def get_password_reset_email(username: str, reset_link: str, expires_hours: int 
     Returns:
         HTML email content.
     """
-    safe_username = _e(username)
-    safe_reset_link = _e(reset_link)
-
-    content = f"""
-        <h2>Password reset request</h2>
-        <p>Hello <strong>{safe_username}</strong>,</p>
-        <p>We received a request to reset your OWASP BLT password.</p>
-
-        <div class="button-wrap">
-            <a href="{safe_reset_link}" class="button">Reset Password</a>
-        </div>
-
-        <div class="info-box">
-            <p><strong>Security notice:</strong> This link expires in {expires_hours} hour(s).</p>
-        </div>
-
-        <p class="muted">If the button does not work, copy and paste this link into your browser:</p>
-        <div class="link-box">{safe_reset_link}</div>
-
-        <div class="divider"></div>
-
-        <p class="muted">
-            If you did not request a password reset, no action is required and your password remains unchanged.
-        </p>
-    """
-    return get_base_template(content, "Reset Your Password - OWASP BLT")
+    content = load_template(
+        'password_reset.html',
+        username=username,
+        reset_link=reset_link,
+        expires_hours=expires_hours
+    )
+    return render_in_base(content, "Reset Your Password - OWASP BLT")
 
 
 def get_welcome_email(username: str, dashboard_link: str) -> str:
@@ -336,33 +132,12 @@ def get_welcome_email(username: str, dashboard_link: str) -> str:
     Returns:
         HTML email content.
     """
-    safe_username = _e(username)
-    safe_dashboard_link = _e(dashboard_link)
-
-    content = f"""
-        <h2>Welcome to OWASP BLT</h2>
-        <p>Hello <strong>{safe_username}</strong>,</p>
-        <p>Your email has been verified and your account is now active.</p>
-
-        <h3>What you can do next</h3>
-        <ul>
-            <li>Submit vulnerability reports.</li>
-            <li>Track review status and feedback.</li>
-            <li>Earn points on the leaderboard.</li>
-            <li>Participate in the security community.</li>
-        </ul>
-
-        <div class="button-wrap">
-            <a href="{safe_dashboard_link}" class="button">Open Dashboard</a>
-        </div>
-
-        <div class="info-box">
-            <p><strong>Tip:</strong> Complete your profile to unlock all contributor features.</p>
-        </div>
-
-        <p>Thank you for helping improve security across the web.</p>
-    """
-    return get_base_template(content, "Welcome to OWASP BLT")
+    content = load_template(
+        'welcome.html',
+        username=username,
+        dashboard_link=dashboard_link
+    )
+    return render_in_base(content, "Welcome to OWASP BLT")
 
 
 def get_bug_submission_confirmation(username: str, bug_id: str, bug_title: str) -> str:
@@ -376,29 +151,10 @@ def get_bug_submission_confirmation(username: str, bug_id: str, bug_title: str) 
     Returns:
         HTML email content.
     """
-    safe_username = _e(username)
-    safe_bug_id = _e(bug_id)
-    safe_bug_title = _e(bug_title)
-
-    content = f"""
-        <h2>Bug submission received</h2>
-        <p>Hello <strong>{safe_username}</strong>,</p>
-        <p>Thank you for reporting a security issue to OWASP BLT. Your submission has been recorded.</p>
-
-        <div class="info-box">
-            <p><strong>Bug ID:</strong> #{safe_bug_id}</p>
-            <p><strong>Title:</strong> {safe_bug_title}</p>
-            <p><strong>Status:</strong> Under review</p>
-        </div>
-
-        <h3>What happens next</h3>
-        <ol>
-            <li>Our security team reviews your submission.</li>
-            <li>The issue is validated and prioritized.</li>
-            <li>Points are awarded based on severity and impact.</li>
-            <li>You receive updates as review progresses.</li>
-        </ol>
-
-        <p>We appreciate your contribution to responsible disclosure.</p>
-    """
-    return get_base_template(content, "Bug Submission Confirmed - OWASP BLT")
+    content = load_template(
+        'bug_confirmation.html',
+        username=username,
+        bug_id=bug_id,
+        bug_title=bug_title
+    )
+    return render_in_base(content, "Bug Submission Confirmed - OWASP BLT")

--- a/src/services/templates/README.md
+++ b/src/services/templates/README.md
@@ -62,7 +62,6 @@ html = get_verification_email(
 ## Adding New Templates
 
 1. Create new `.html` file in this directory
-2. Add placeholders using `{variable_name}` syntax
 2. Add placeholders using `[[variable_name]]` syntax (double square brackets)
 
 ```python

--- a/src/services/templates/README.md
+++ b/src/services/templates/README.md
@@ -1,0 +1,103 @@
+# Email Templates
+
+This directory contains HTML email templates for the BLT API.
+
+## Template Files
+
+| File | Purpose | Variables |
+|------|---------|-----------|
+| `base.html` | Base layout wrapper | `[[title]]`, `[[content]]` |
+| `verification.html` | Email verification | `[[username]]`, `[[verification_link]]`, `[[expires_hours]]` |
+| `password_reset.html` | Password reset | `[[username]]`, `[[reset_link]]`, `[[expires_hours]]` |
+| `welcome.html` | Welcome email | `[[username]]`, `[[dashboard_link]]` |
+| `bug_confirmation.html` | Bug submission | `[[username]]`, `[[bug_id]]`, `[[bug_title]]` |
+
+## 🎨 How It Works
+
+1. **Separate HTML from Python** - All HTML is in external `.html` files
+2. **Dynamic placeholders** - Use `[[variable_name]]` syntax for dynamic content
+3. **Auto-escaping** - All variables are automatically HTML-escaped for security
+4. **Template inheritance** - Content templates are wrapped in `base.html` layout
+5. **Valid CSS** - CSS uses normal `{}` braces, no conflicts with placeholders
+
+## Usage Example
+
+### Python Code
+```python
+from services.email_templates import get_verification_email
+
+html = get_verification_email(
+    username="john_doe",
+    verification_link="https://blt.owasp.org/verify?token=abc123",
+    expires_hours=24
+)
+```
+
+### Template File (`verification.html`)
+```html
+<p>Hello <strong>[[username]]</strong>,</p>
+<a href="[[verification_link]]" class="button">Verify Email</a>
+<p>Expires in [[expires_hours]] hours.</p>
+```
+
+### Rendered Output
+```html
+<p>Hello <strong>john_doe</strong>,</p>
+<a href="https://blt.owasp.org/verify?token=abc123" class="button">Verify Email</a>
+<p>Expires in 24 hours.</p>
+```
+
+## ✏️ Editing Templates
+
+1. **Preview changes** - Open `.html` files in browser to preview (CSS works perfectly!)
+2. **Edit freely** - No Python knowledge needed to modify templates
+3. **Use placeholders** - Add `[[variable_name]]` where you need dynamic content
+4. **Keep styling** - All CSS classes are defined in `base.html` with normal `{}` braces
+
+## Security
+
+- **XSS Protection** - All variables are automatically HTML-escaped
+- **No code execution** - Templates are pure HTML with safe string replacement
+- **Validation** - Missing variables throw clear error messages- **CSS Safe** - Uses `[[var]]` syntax to avoid conflicts with CSS `{}` braces
+## Adding New Templates
+
+1. Create new `.html` file in this directory
+2. Add placeholders using `{variable_name}` syntax
+2. Add placeholders using `[[variable_name]]` syntax (double square brackets)
+
+```python
+def get_my_new_email(var1: str, var2: str) -> str:
+    """Description of the email."""
+    content = load_template(
+        'my_new_email.html',
+        var1=var1,
+        var2=var2
+    )
+    return render_in_base(content, "Email Title - OWASP BLT")
+```
+
+## CSS Classes
+
+Common CSS classes available in templates:
+
+- `.button` - Primary action button (red)
+- `.button-wrap` - Center-aligned button container
+- `.info-box` - Highlighted info box (red border)
+- `.link-box` - Copyable link display
+- `.divider` - Horizontal separator line
+- `.muted` - Gray secondary text
+- `.small` - Smaller text for disclaimers
+
+## Email Best Practices
+
+**Do:**
+- Keep content concise and scannable
+- Use clear call-to-action buttons
+- Include plain text fallback links
+- Test on multiple email clients
+
+**Don't:**
+- Use JavaScript (not supported in emails)
+- Use external CSS files (inline styles only)
+- Forget mobile responsiveness
+- Include sensitive data in links

--- a/src/services/templates/base.html
+++ b/src/services/templates/base.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>[[title]]</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            width: 100% !important;
+            background-color: #f5f5f5;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: #1f2937;
+            line-height: 1.6;
+        }
+        table {
+            border-spacing: 0;
+            border-collapse: collapse;
+        }
+        .wrapper {
+            width: 100%;
+            background-color: #f5f5f5;
+            padding: 24px 12px;
+        }
+        .container {
+            width: 100%;
+            max-width: 640px;
+            margin: 0 auto;
+            background: #ffffff;
+            border: 1px solid #e5e5e5;
+            border-radius: 12px;
+            overflow: hidden;
+        }
+        .header {
+            background-color: #111827;
+            border-bottom: 4px solid #e10101;
+            padding: 28px 28px 22px;
+            text-align: center;
+        }
+        .header h1 {
+            margin: 0;
+            color: #ffffff;
+            font-size: 26px;
+            font-weight: 700;
+            letter-spacing: 0.3px;
+        }
+        .header p {
+            margin: 6px 0 0;
+            color: #d1d5db;
+            font-size: 13px;
+        }
+        .content {
+            padding: 30px 28px 12px;
+        }
+        .content h2 {
+            margin: 0 0 14px;
+            font-size: 24px;
+            line-height: 1.3;
+            color: #111827;
+            font-weight: 700;
+        }
+        .content h3 {
+            margin: 24px 0 10px;
+            font-size: 18px;
+            line-height: 1.4;
+            color: #111827;
+            font-weight: 700;
+        }
+        .content p {
+            margin: 0 0 14px;
+            color: #374151;
+            font-size: 15px;
+        }
+        .content a {
+            color: #e10101;
+            text-decoration: none;
+        }
+        .content a:hover {
+            text-decoration: underline;
+        }
+        .button-wrap {
+            text-align: center;
+            padding: 8px 0 10px;
+        }
+        .button {
+            display: inline-block;
+            background-color: #e10101;
+            color: #ffffff !important;
+            text-decoration: none;
+            font-size: 15px;
+            font-weight: 700;
+            padding: 12px 24px;
+            border-radius: 8px;
+            border: 1px solid #e10101;
+        }
+        .button:hover {
+            background-color: #b91c1c;
+            border-color: #b91c1c;
+            text-decoration: none;
+        }
+        .link-box {
+            margin: 16px 0 22px;
+            padding: 12px 14px;
+            border: 1px solid #e5e5e5;
+            border-radius: 8px;
+            background-color: #fafafa;
+            color: #111827;
+            font-size: 13px;
+            word-break: break-all;
+        }
+        .info-box {
+            margin: 16px 0;
+            padding: 12px 14px;
+            background-color: #fef2f2;
+            border-left: 4px solid #e10101;
+            border-radius: 6px;
+        }
+        .info-box p {
+            margin: 0;
+            color: #7f1d1d;
+            font-size: 14px;
+        }
+        .divider {
+            height: 1px;
+            background-color: #e5e5e5;
+            margin: 22px 0;
+        }
+        ul, ol {
+            margin: 8px 0 16px;
+            padding-left: 20px;
+            color: #374151;
+            font-size: 15px;
+        }
+        li {
+            margin: 7px 0;
+        }
+        .footer {
+            padding: 20px 28px 28px;
+            border-top: 1px solid #e5e5e5;
+            background-color: #fafafa;
+            text-align: center;
+        }
+        .footer p {
+            margin: 0 0 8px;
+            color: #6b7280;
+            font-size: 13px;
+        }
+        .footer a {
+            color: #e10101;
+            text-decoration: none;
+            font-weight: 600;
+        }
+        .muted {
+            color: #6b7280;
+            font-size: 13px;
+        }
+        .small {
+            font-size: 12px;
+            color: #9ca3af;
+        }
+        @media only screen and (max-width: 640px) {
+            .wrapper {
+                padding: 12px 0;
+            }
+            .container {
+                border-radius: 0;
+                border-left: none;
+                border-right: none;
+            }
+            .header,
+            .content,
+            .footer {
+                padding-left: 18px;
+                padding-right: 18px;
+            }
+            .content h2 {
+                font-size: 22px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <span style="display:none !important; visibility:hidden; opacity:0; color:transparent; height:0; width:0; overflow:hidden;">
+        [[title]]
+    </span>
+
+    <table role="presentation" width="100%" class="wrapper">
+        <tr>
+            <td align="center">
+                <table role="presentation" width="100%" class="container">
+                    <tr>
+                        <td class="header">
+                            <h1>OWASP BLT</h1>
+                            <p>Bug Logging Tool</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="content">
+                            [[content]]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="footer">
+                            <p><strong>OWASP Bug Logging Tool</strong></p>
+                            <p>Making the web more secure, one report at a time.</p>
+                            <p>
+                                <a href="https://owaspblt.org">Website</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://github.com/OWASP-BLT">GitHub</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://owasp.org">OWASP</a>
+                            </p>
+                            <p class="small">This is an automated message. Please do not reply to this email.</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/src/services/templates/bug_confirmation.html
+++ b/src/services/templates/bug_confirmation.html
@@ -1,0 +1,19 @@
+<h2>Bug submission received</h2>
+<p>Hello <strong>[[username]]</strong>,</p>
+<p>Thank you for reporting a security issue to OWASP BLT. Your submission has been recorded.</p>
+
+<div class="info-box">
+    <p><strong>Bug ID:</strong> #[[bug_id]]</p>
+    <p><strong>Title:</strong> [[bug_title]]</p>
+    <p><strong>Status:</strong> Under review</p>
+</div>
+
+<h3>What happens next</h3>
+<ol>
+    <li>Our security team reviews your submission.</li>
+    <li>The issue is validated and prioritized.</li>
+    <li>Points are awarded based on severity and impact.</li>
+    <li>You receive updates as review progresses.</li>
+</ol>
+
+<p>We appreciate your contribution to responsible disclosure.</p>

--- a/src/services/templates/password_reset.html
+++ b/src/services/templates/password_reset.html
@@ -1,0 +1,20 @@
+<h2>Password reset request</h2>
+<p>Hello <strong>[[username]]</strong>,</p>
+<p>We received a request to reset your OWASP BLT password.</p>
+
+<div class="button-wrap">
+    <a href="[[reset_link]]" class="button">Reset Password</a>
+</div>
+
+<div class="info-box">
+    <p><strong>Security notice:</strong> This link expires in [[expires_hours]] hour(s).</p>
+</div>
+
+<p class="muted">If the button does not work, copy and paste this link into your browser:</p>
+<div class="link-box">[[reset_link]]</div>
+
+<div class="divider"></div>
+
+<p class="muted">
+    If you did not request a password reset, no action is required and your password remains unchanged.
+</p>

--- a/src/services/templates/verification.html
+++ b/src/services/templates/verification.html
@@ -1,0 +1,18 @@
+<h2>Verify your email address</h2>
+<p>Hello <strong>[[username]]</strong>,</p>
+<p>Thanks for registering with OWASP BLT. Confirm your email address to activate your account.</p>
+
+<div class="button-wrap">
+    <a href="[[verification_link]]" class="button">Verify Email</a>
+</div>
+
+<div class="info-box">
+    <p><strong>Important:</strong> This verification link expires in [[expires_hours]] hours.</p>
+</div>
+
+<p class="muted">If the button does not work, copy and paste this link into your browser:</p>
+<div class="link-box">[[verification_link]]</div>
+
+<div class="divider"></div>
+
+<p class="muted">If you did not create an OWASP BLT account, you can safely ignore this email.</p>

--- a/src/services/templates/welcome.html
+++ b/src/services/templates/welcome.html
@@ -1,0 +1,21 @@
+<h2>Welcome to OWASP BLT</h2>
+<p>Hello <strong>[[username]]</strong>,</p>
+<p>Your email has been verified and your account is now active.</p>
+
+<h3>What you can do next</h3>
+<ul>
+    <li>Submit vulnerability reports.</li>
+    <li>Track review status and feedback.</li>
+    <li>Earn points on the leaderboard.</li>
+    <li>Participate in the security community.</li>
+</ul>
+
+<div class="button-wrap">
+    <a href="[[dashboard_link]]" class="button">Open Dashboard</a>
+</div>
+
+<div class="info-box">
+    <p><strong>Tip:</strong> Complete your profile to unlock all contributor features.</p>
+</div>
+
+<p>Thank you for helping improve security across the web.</p>


### PR DESCRIPTION
Fixes: #24 
## Screenshot working
<img width="1217" height="698" alt="image" src="https://github.com/user-attachments/assets/a6314d96-bd7f-402b-bf9f-b917c641f85b" />
<img width="1470" height="886" alt="image" src="https://github.com/user-attachments/assets/dc96c41e-2c7c-4ec7-a340-c0f1c42a27e6" />

After extraction the value passing and html is been rendred as previuosly. 