### PR TITLE
fix(path): replace fragile relative paths with pathlib absolute resolution

### DIFF
--- a/src/handlers/homepage.py
+++ b/src/handlers/homepage.py
@@ -46,7 +46,7 @@ async def handle_homepage(
     else:
         base_url = "https://blt-api.workers.dev"
     
-    html_file = Path(__file__).parent / "../pages/index.html"
+    html_file = Path(__file__).resolve().parent.parent / "pages" / "index.html"
     html_content = html_file.read_text().replace("[[API_BASE_URL]]", base_url)
     
     # Create HTML response with proper headers

--- a/src/services/email_templates.py
+++ b/src/services/email_templates.py
@@ -5,11 +5,10 @@ Clean separation of templates and code - templates are stored as external HTML f
 
 from pathlib import Path
 from html import escape
-import os
 
 
 # Get the templates directory path
-TEMPLATES_DIR = Path(__file__).parent / "templates"
+TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
 
 
 def _e(value) -> str:

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -4,10 +4,10 @@ Tests for the homepage handler.
 
 import pytest
 import sys
-import os
+from pathlib import Path
 
 # Add src to path for imports to work
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from handlers.homepage import handle_homepage
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -9,9 +9,9 @@ last executed SQL / parameters are captured for assertion.
 
 import pytest
 import sys
-import os
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from libs.orm import (
     QuerySet,


### PR DESCRIPTION
##  Fix: Absolute Path Resolution via `pathlib`

Replaces all fragile `os.path` relative traversals with `pathlib`-based 
absolute resolution — ensuring the API works correctly regardless of where 
the process is launched from.

---

### Files Changed

| File | Change |
|---|---|
| `src/handlers/homepage.py` | `Path.resolve()` + clean parent traversal |
| `src/services/email_templates.py` | `Path.resolve()` on `TEMPLATES_DIR` + removed unused `import os` |
| `tests/test_homepage.py` | Replaced `os.path.join` with `pathlib` |
| `tests/test_orm.py` | Replaced `os.path.join` with `pathlib` |

---

###  Verified

- Zero `os.path` or `../` patterns remaining in `src/`
- Import resolution confirmed working via manual test