### PR TITLE
refactor(stats): replace inline D1 row conversion with existing utility helper

### DIFF
--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -4,7 +4,7 @@ Stats handler for the BLT API.
 
 import logging
 from typing import Any, Dict
-from utils import json_response, error_response
+from utils import json_response, error_response, convert_single_d1_result
 from libs.db import get_db_safe
 
 
@@ -31,13 +31,13 @@ async def handle_stats(
 
     try:
         bugs_result = await db.prepare('SELECT COUNT(*) as count FROM bugs').first()
-        bugs_count = (bugs_result.to_py() if hasattr(bugs_result, 'to_py') else dict(bugs_result)).get('count', 0)
+        bugs_count = (await convert_single_d1_result(bugs_result)).get('count', 0)
 
         users_result = await db.prepare('SELECT COUNT(*) as count FROM users WHERE is_active = 1').first()
-        users_count = (users_result.to_py() if hasattr(users_result, 'to_py') else dict(users_result)).get('count', 0)
+        users_count = (await convert_single_d1_result(users_result)).get('count', 0)
 
         domains_result = await db.prepare('SELECT COUNT(*) as count FROM domains WHERE is_active = 1').first()
-        domains_count = (domains_result.to_py() if hasattr(domains_result, 'to_py') else dict(domains_result)).get('count', 0)
+        domains_count = (await convert_single_d1_result(domains_result)).get('count', 0)
 
         return json_response({
             "success": True,


### PR DESCRIPTION
##  Refactor: Stats Handler Cleanup

The `/stats` handler was repeating the same inline D1 result conversion 
pattern 3 times. `utils.py` already exposes `convert_single_d1_result()` 
for exactly this purpose — this PR wires it in.

###  Files Changed

| File | Change |
|---|---|
| `src/handlers/stats.py` | Replace 3x inline `to_py/dict` pattern with `convert_single_d1_result` |

###  Result
- Removes code duplication
- Consistent with existing utility patterns in `utils.py`
- No behaviour change