### PR TITLE
feat(stats): add open/closed bug breakdown to /stats endpoint

### DIFF
--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -38,7 +38,8 @@ async def handle_stats(
         return json_response({
             "success": True,
             "data": {
-                "bugs": {
+                "bugs": total_bugs,
+                "bugs_breakdown": {
                     "total": total_bugs,
                     "open": open_bugs,
                     "closed": closed_bugs,
@@ -47,7 +48,8 @@ async def handle_stats(
                 "domains": domains_count,
             },
             "description": {
-                "bugs": "Bug counts by status (total, open, closed)",
+                "bugs": "Total number of bugs reported",
+                "bugs_breakdown": "Bug counts by status (total, open, closed)",
                 "users": "Total number of active registered users",
                 "domains": "Total number of active tracked domains",
             }

--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -1,11 +1,11 @@
 """
 Stats handler for the BLT API.
 """
-
 import logging
 from typing import Any, Dict
 from utils import json_response, error_response
 from libs.db import get_db_safe
+from models import Bug, User, Domain
 
 
 async def handle_stats(
@@ -22,7 +22,6 @@ async def handle_stats(
         GET /stats - Get overall platform statistics
     """
     logger = logging.getLogger(__name__)
-
     try:
         db = await get_db_safe(env)
     except Exception as e:
@@ -30,40 +29,25 @@ async def handle_stats(
         return error_response(f"Database connection error: {str(e)}", status=500)
 
     try:
-        bugs_result = await db.prepare(
-            """
-            SELECT
-                COUNT(*) AS total,
-                COALESCE(SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END), 0) AS open,
-                COALESCE(SUM(CASE WHEN status = 'closed' THEN 1 ELSE 0 END), 0) AS closed
-            FROM bugs
-            """
-        ).first()
-        bugs_row = bugs_result.to_py() if hasattr(bugs_result, "to_py") else dict(bugs_result)
-        bugs_count = bugs_row.get("total", 0)
-        open_bugs_count = bugs_row.get("open", 0)
-        closed_bugs_count = bugs_row.get("closed", 0)
-
-        users_result = await db.prepare('SELECT COUNT(*) as count FROM users WHERE is_active = 1').first()
-        users_count = (users_result.to_py() if hasattr(users_result, 'to_py') else dict(users_result)).get('count', 0)
-
-        domains_result = await db.prepare('SELECT COUNT(*) as count FROM domains WHERE is_active = 1').first()
-        domains_count = (domains_result.to_py() if hasattr(domains_result, 'to_py') else dict(domains_result)).get('count', 0)
+        total_bugs = await Bug.objects(db).count()
+        open_bugs = await Bug.objects(db).filter(status='open').count()
+        closed_bugs = await Bug.objects(db).filter(status='closed').count()
+        users_count = await User.objects(db).filter(is_active=1).count()
+        domains_count = await Domain.objects(db).filter(is_active=1).count()
 
         return json_response({
             "success": True,
             "data": {
-                "bugs": bugs_count,
-                "bug_breakdown": {
-                    "open": open_bugs_count,
-                    "closed": closed_bugs_count,
+                "bugs": {
+                    "total": total_bugs,
+                    "open": open_bugs,
+                    "closed": closed_bugs,
                 },
                 "users": users_count,
                 "domains": domains_count,
             },
             "description": {
-                "bugs": "Total number of bugs reported",
-                "bug_breakdown": "Bug report counts by status",
+                "bugs": "Bug counts by status (total, open, closed)",
                 "users": "Total number of active registered users",
                 "domains": "Total number of active tracked domains",
             }
@@ -71,4 +55,3 @@ async def handle_stats(
     except Exception as e:
         logger.error(f"Error fetching stats: {str(e)}")
         return error_response(f"Error fetching stats: {str(e)}", status=500)
-    

--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -17,7 +17,7 @@ async def handle_stats(
 ) -> Any:
     """
     Handle statistics-related requests.
-    
+
     Endpoints:
         GET /stats - Get overall platform statistics
     """
@@ -33,6 +33,12 @@ async def handle_stats(
         bugs_result = await db.prepare('SELECT COUNT(*) as count FROM bugs').first()
         bugs_count = (await convert_single_d1_result(bugs_result)).get('count', 0)
 
+        open_bugs_result = await db.prepare("SELECT COUNT(*) as count FROM bugs WHERE status = 'open'").first()
+        open_bugs_count = (open_bugs_result.to_py() if hasattr(open_bugs_result, 'to_py') else dict(open_bugs_result)).get('count', 0)
+
+        closed_bugs_result = await db.prepare("SELECT COUNT(*) as count FROM bugs WHERE status = 'closed'").first()
+        closed_bugs_count = (closed_bugs_result.to_py() if hasattr(closed_bugs_result, 'to_py') else dict(closed_bugs_result)).get('count', 0)
+
         users_result = await db.prepare('SELECT COUNT(*) as count FROM users WHERE is_active = 1').first()
         users_count = (await convert_single_d1_result(users_result)).get('count', 0)
 
@@ -42,16 +48,21 @@ async def handle_stats(
         return json_response({
             "success": True,
             "data": {
-                "bugs": bugs_count,
+                "bugs": {
+                    "total": bugs_count,
+                    "open": open_bugs_count,
+                    "closed": closed_bugs_count,
+                },
                 "users": users_count,
                 "domains": domains_count,
             },
             "description": {
-                "bugs": "Total number of bugs reported",
-                "users": "Total number of registered users",
-                "domains": "Total number of tracked domains",
+                "bugs": "Bug report counts by status",
+                "users": "Total number of active registered users",
+                "domains": "Total number of active tracked domains",
             }
         })
     except Exception as e:
         logger.error(f"Error fetching stats: {str(e)}")
         return error_response(f"Error fetching stats: {str(e)}", status=500)
+    

--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -32,8 +32,10 @@ async def handle_stats(
         total_bugs = await Bug.objects(db).count()
         open_bugs = await Bug.objects(db).filter(status='open').count()
         closed_bugs = await Bug.objects(db).filter(status='closed').count()
-        users_count = await User.objects(db).filter(is_active=1).count()
-        domains_count = await Domain.objects(db).filter(is_active=1).count()
+        users_count = await User.objects(db).count()
+        active_users_count = await User.objects(db).filter(is_active=1).count()
+        domains_count = await Domain.objects(db).count()
+        active_domains_count = await Domain.objects(db).filter(is_active=1).count()
 
         return json_response({
             "success": True,
@@ -45,13 +47,17 @@ async def handle_stats(
                     "closed": closed_bugs,
                 },
                 "users": users_count,
+                "active_users": active_users_count,
                 "domains": domains_count,
+                "active_domains": active_domains_count,
             },
             "description": {
                 "bugs": "Total number of bugs reported",
                 "bugs_breakdown": "Bug counts by status (total, open, closed)",
-                "users": "Total number of active registered users",
-                "domains": "Total number of active tracked domains",
+                "users": "Total number of registered users",
+                "active_users": "Total number of active registered users",
+                "domains": "Total number of tracked domains",
+                "active_domains": "Total number of active tracked domains",
             }
         })
     except Exception as e:

--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -34,8 +34,8 @@ async def handle_stats(
             """
             SELECT
                 COUNT(*) AS total,
-                SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) AS open,
-                SUM(CASE WHEN status = 'closed' THEN 1 ELSE 0 END) AS closed
+                COALESCE(SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END), 0) AS open,
+                COALESCE(SUM(CASE WHEN status = 'closed' THEN 1 ELSE 0 END), 0) AS closed
             FROM bugs
             """
         ).first()

--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -4,7 +4,7 @@ Stats handler for the BLT API.
 
 import logging
 from typing import Any, Dict
-from utils import json_response, error_response, convert_single_d1_result
+from utils import json_response, error_response
 from libs.db import get_db_safe
 
 
@@ -30,26 +30,31 @@ async def handle_stats(
         return error_response(f"Database connection error: {str(e)}", status=500)
 
     try:
-        bugs_result = await db.prepare('SELECT COUNT(*) as count FROM bugs').first()
-        bugs_count = (await convert_single_d1_result(bugs_result)).get('count', 0)
-
-        open_bugs_result = await db.prepare("SELECT COUNT(*) as count FROM bugs WHERE status = 'open'").first()
-        open_bugs_count = (open_bugs_result.to_py() if hasattr(open_bugs_result, 'to_py') else dict(open_bugs_result)).get('count', 0)
-
-        closed_bugs_result = await db.prepare("SELECT COUNT(*) as count FROM bugs WHERE status = 'closed'").first()
-        closed_bugs_count = (closed_bugs_result.to_py() if hasattr(closed_bugs_result, 'to_py') else dict(closed_bugs_result)).get('count', 0)
+        bugs_result = await db.prepare(
+            """
+            SELECT
+                COUNT(*) AS total,
+                SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) AS open,
+                SUM(CASE WHEN status = 'closed' THEN 1 ELSE 0 END) AS closed
+            FROM bugs
+            """
+        ).first()
+        bugs_row = bugs_result.to_py() if hasattr(bugs_result, "to_py") else dict(bugs_result)
+        bugs_count = bugs_row.get("total", 0)
+        open_bugs_count = bugs_row.get("open", 0)
+        closed_bugs_count = bugs_row.get("closed", 0)
 
         users_result = await db.prepare('SELECT COUNT(*) as count FROM users WHERE is_active = 1').first()
-        users_count = (await convert_single_d1_result(users_result)).get('count', 0)
+        users_count = (users_result.to_py() if hasattr(users_result, 'to_py') else dict(users_result)).get('count', 0)
 
         domains_result = await db.prepare('SELECT COUNT(*) as count FROM domains WHERE is_active = 1').first()
-        domains_count = (await convert_single_d1_result(domains_result)).get('count', 0)
+        domains_count = (domains_result.to_py() if hasattr(domains_result, 'to_py') else dict(domains_result)).get('count', 0)
 
         return json_response({
             "success": True,
             "data": {
-                "bugs": {
-                    "total": bugs_count,
+                "bugs": bugs_count,
+                "bug_breakdown": {
                     "open": open_bugs_count,
                     "closed": closed_bugs_count,
                 },
@@ -57,7 +62,8 @@ async def handle_stats(
                 "domains": domains_count,
             },
             "description": {
-                "bugs": "Bug report counts by status",
+                "bugs": "Total number of bugs reported",
+                "bug_breakdown": "Bug report counts by status",
                 "users": "Total number of active registered users",
                 "domains": "Total number of active tracked domains",
             }

--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -24,9 +24,9 @@ async def handle_stats(
     logger = logging.getLogger(__name__)
     try:
         db = await get_db_safe(env)
-    except Exception as e:
-        logger.error(f"Database connection error: {e!s}")
-        return error_response(f"Database connection error: {e!s}", status=500)
+    except Exception:
+        logger.exception("Database connection error")
+        return error_response("Database connection error", status=500)
 
     try:
         total_bugs = await Bug.objects(db).count()
@@ -62,6 +62,6 @@ async def handle_stats(
                 "active_domains": "Total number of active tracked domains",
             }
         })
-    except Exception as e:
-        logger.error(f"Error fetching stats: {e!s}")
-        return error_response(f"Error fetching stats: {e!s}", status=500)
+    except Exception:
+        logger.exception("Error fetching stats")
+        return error_response("Internal server error", status=500)

--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -25,8 +25,8 @@ async def handle_stats(
     try:
         db = await get_db_safe(env)
     except Exception as e:
-        logger.error(f"Database connection error: {str(e)}")
-        return error_response(f"Database connection error: {str(e)}", status=500)
+        logger.error(f"Database connection error: {e!s}")
+        return error_response(f"Database connection error: {e!s}", status=500)
 
     try:
         total_bugs = await Bug.objects(db).count()
@@ -63,5 +63,5 @@ async def handle_stats(
             }
         })
     except Exception as e:
-        logger.error(f"Error fetching stats: {str(e)}")
-        return error_response(f"Error fetching stats: {str(e)}", status=500)
+        logger.error(f"Error fetching stats: {e!s}")
+        return error_response(f"Error fetching stats: {e!s}", status=500)

--- a/src/handlers/stats.py
+++ b/src/handlers/stats.py
@@ -32,10 +32,11 @@ async def handle_stats(
         total_bugs = await Bug.objects(db).count()
         open_bugs = await Bug.objects(db).filter(status='open').count()
         closed_bugs = await Bug.objects(db).filter(status='closed').count()
-        users_count = await User.objects(db).count()
-        active_users_count = await User.objects(db).filter(is_active=1).count()
-        domains_count = await Domain.objects(db).count()
-        active_domains_count = await Domain.objects(db).filter(is_active=1).count()
+        other_bugs = total_bugs - open_bugs - closed_bugs
+        users_count = await User.objects(db).filter(is_active=1).count()
+        active_users_count = users_count
+        domains_count = await Domain.objects(db).filter(is_active=1).count()
+        active_domains_count = domains_count
 
         return json_response({
             "success": True,
@@ -45,6 +46,7 @@ async def handle_stats(
                     "total": total_bugs,
                     "open": open_bugs,
                     "closed": closed_bugs,
+                    "other": other_bugs,
                 },
                 "users": users_count,
                 "active_users": active_users_count,
@@ -53,10 +55,10 @@ async def handle_stats(
             },
             "description": {
                 "bugs": "Total number of bugs reported",
-                "bugs_breakdown": "Bug counts by status (total, open, closed)",
-                "users": "Total number of registered users",
+                "bugs_breakdown": "Bug counts by status (total, open, closed, other)",
+                "users": "Total number of active registered users",
                 "active_users": "Total number of active registered users",
-                "domains": "Total number of tracked domains",
+                "domains": "Total number of active tracked domains",
                 "active_domains": "Total number of active tracked domains",
             }
         })

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -10,7 +10,8 @@ from pathlib import Path
 
 SRC_PATH = Path(__file__).resolve().parent.parent / "src"
 sys.path.insert(0, str(SRC_PATH))
-
+# Importing handlers.stats via package triggers handlers/__init__.py, which imports
+# workers-dependent modules not available in this isolated test environment.
 stats_spec = importlib.util.spec_from_file_location(
     "stats_handler_module",
     SRC_PATH / "handlers" / "stats.py",

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -134,7 +134,7 @@ class TestStatsHandler:
         assert response.status == 500
         assert payload["error"] is True
         assert payload["status"] == 500
-        assert payload["message"] == "Database connection error: db unavailable"
+        assert payload["message"] == "Database connection error"
 
     @pytest.mark.asyncio
     async def test_stats_returns_error_when_count_query_fails(self, monkeypatch):
@@ -159,4 +159,4 @@ class TestStatsHandler:
         assert response.status == 500
         assert payload["error"] is True
         assert payload["status"] == 500
-        assert payload["message"] == "Error fetching stats: count failed"
+        assert payload["message"] == "Internal server error"

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,161 @@
+"""
+Tests for the stats handler.
+"""
+
+import importlib.util
+import json
+import pytest
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC_PATH))
+
+stats_spec = importlib.util.spec_from_file_location(
+    "stats_handler_module",
+    SRC_PATH / "handlers" / "stats.py",
+)
+stats_handler = importlib.util.module_from_spec(stats_spec)
+stats_spec.loader.exec_module(stats_handler)
+
+
+class MockRequest:
+    """Mock request object for testing."""
+
+    method = "GET"
+
+
+class MockEnv:
+    """Mock environment object for testing."""
+
+    pass
+
+
+class FakeQuerySet:
+    """Minimal queryset stub for count-based handler tests."""
+
+    def __init__(self, counts, filters=None, error=None):
+        self._counts = counts
+        self._filters = filters or {}
+        self._error = error
+
+    def filter(self, **kwargs):
+        next_filters = dict(self._filters)
+        next_filters.update(kwargs)
+        return FakeQuerySet(self._counts, filters=next_filters, error=self._error)
+
+    async def count(self):
+        if self._error is not None:
+            raise self._error
+        key = tuple(sorted(self._filters.items()))
+        return self._counts.get(key, 0)
+
+
+class FakeModel:
+    """Model stub exposing the objects(db) API used by the handler."""
+
+    def __init__(self, counts, error=None):
+        self._counts = counts
+        self._error = error
+
+    def objects(self, db):
+        return FakeQuerySet(self._counts, error=self._error)
+
+
+def parse_response(response):
+    """Decode a mocked JSON response body into a Python object."""
+
+    return json.loads(response.body)
+
+
+class TestStatsHandler:
+    """Tests for the /stats handler."""
+
+    @pytest.mark.asyncio
+    async def test_stats_returns_backward_compatible_counts(self, monkeypatch):
+        async def fake_get_db_safe(env):
+            return object()
+
+        monkeypatch.setattr(stats_handler, "get_db_safe", fake_get_db_safe)
+        monkeypatch.setattr(
+            stats_handler,
+            "Bug",
+            FakeModel({(): 8, (("status", "open"),): 3, (("status", "closed"),): 4}),
+        )
+        monkeypatch.setattr(stats_handler, "User", FakeModel({(("is_active", 1),): 5}))
+        monkeypatch.setattr(stats_handler, "Domain", FakeModel({(("is_active", 1),): 2}))
+
+        response = await stats_handler.handle_stats(
+            MockRequest(),
+            MockEnv(),
+            path_params={},
+            query_params={},
+            path="/stats",
+        )
+
+        payload = parse_response(response)
+
+        assert response.status == 200
+        assert payload["success"] is True
+        assert payload["data"] == {
+            "bugs": 8,
+            "bugs_breakdown": {
+                "total": 8,
+                "open": 3,
+                "closed": 4,
+                "other": 1,
+            },
+            "users": 5,
+            "active_users": 5,
+            "domains": 2,
+            "active_domains": 2,
+        }
+        assert payload["description"]["users"] == "Total number of active registered users"
+        assert payload["description"]["domains"] == "Total number of active tracked domains"
+
+    @pytest.mark.asyncio
+    async def test_stats_returns_error_when_db_connection_fails(self, monkeypatch):
+        async def fake_get_db_safe(env):
+            raise RuntimeError("db unavailable")
+
+        monkeypatch.setattr(stats_handler, "get_db_safe", fake_get_db_safe)
+
+        response = await stats_handler.handle_stats(
+            MockRequest(),
+            MockEnv(),
+            path_params={},
+            query_params={},
+            path="/stats",
+        )
+
+        payload = parse_response(response)
+
+        assert response.status == 500
+        assert payload["error"] is True
+        assert payload["status"] == 500
+        assert payload["message"] == "Database connection error: db unavailable"
+
+    @pytest.mark.asyncio
+    async def test_stats_returns_error_when_count_query_fails(self, monkeypatch):
+        async def fake_get_db_safe(env):
+            return object()
+
+        monkeypatch.setattr(stats_handler, "get_db_safe", fake_get_db_safe)
+        monkeypatch.setattr(stats_handler, "Bug", FakeModel({}, error=RuntimeError("count failed")))
+        monkeypatch.setattr(stats_handler, "User", FakeModel({(("is_active", 1),): 5}))
+        monkeypatch.setattr(stats_handler, "Domain", FakeModel({(("is_active", 1),): 2}))
+
+        response = await stats_handler.handle_stats(
+            MockRequest(),
+            MockEnv(),
+            path_params={},
+            query_params={},
+            path="/stats",
+        )
+
+        payload = parse_response(response)
+
+        assert response.status == 500
+        assert payload["error"] is True
+        assert payload["status"] == 500
+        assert payload["message"] == "Error fetching stats: count failed"


### PR DESCRIPTION
## Summary
Extends the `/stats` endpoint to include open and closed bug counts 
alongside the existing total, giving API consumers a complete status 
breakdown in a single request.

## Changes
- Added query for bugs with `status = 'open'`
- Added query for bugs with `status = 'closed'`
- Changed `bugs` field from a flat integer to a structured object

## Why
The previous response required consumers to make additional filtered 
requests to get open/closed counts. This change removes that need and 
aligns the stats endpoint with what BLT-Pages and BLT-Monitor already 
display in their dashboards.

## Testing
- Existing tests pass (`test_domain.py`, `test_orm.py` sync tests)
- No breaking changes to other handlers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stats payload now includes bugs_breakdown (total/open/closed/other) plus active_users and active_domains, with expanded descriptions.

* **Bug Fixes**
  * More accurate counts using active-only filters and improved DB error handling and messages (consistent 500 responses).

* **Tests**
  * Added unit tests for successful stats responses and DB/query failure scenarios.

* **Documentation**
  * Updated metric descriptions to reflect the new breakdown and active counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->