### PR TITLE
fix(bugs): validate URL protocol and format on POST /bugs

### DIFF
--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -194,8 +194,26 @@ async def handle_bugs(
             )
         
         # Validate URL length
+        # Validate URL length
         if len(body["url"]) > 200:
             return error_response("URL must be 200 characters or less", status=400)
+
+        # Validate URL format and protocol
+        try:
+            from urllib.parse import urlparse
+            parsed = urlparse(body["url"])
+            if parsed.scheme not in ("http", "https"):
+                return error_response(
+                    "URL must use http or https protocol",
+                    status=400
+                )
+            if not parsed.netloc:
+                return error_response(
+                    "URL must include a valid domain",
+                    status=400
+                )
+        except Exception:
+            return error_response("Invalid URL format", status=400)
         
         try:
             # Insert the new bug - use None for NULL values

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -193,7 +193,7 @@ async def handle_bugs(
                 status=400
             )
         
-        # Validate URL length
+        
         # Validate URL length
         if len(body["url"]) > 200:
             return error_response("URL must be 200 characters or less", status=400)


### PR DESCRIPTION
## Summary
Adds URL protocol and domain validation to the POST /bugs endpoint 
to prevent invalid or malicious URLs from being stored.

## Changes
- Validates URL uses `http` or `https` protocol (blocks `javascript:`, `ftp:`, etc.)
- Validates URL contains a valid domain via `netloc` check
- Returns clear 400 error messages for each validation failure

## Testing
- Existing tests pass (`test_domain.py`, `test_orm.py` sync tests)
- No breaking changes to other endpoints