### PR TITLE
fix(auth): return 405 Method Not Allowed instead of 404 for wrong HTTP methods

### DIFF
--- a/src/handlers/auth.py
+++ b/src/handlers/auth.py
@@ -69,7 +69,7 @@ async def handle_signup(
     method = str(request.method).upper()
     logger = logging.getLogger(__name__)
     if method != "POST":
-        return error_response( "Method Not Allowed", 404)
+        return error_response( "Method Not Allowed", 405)
     try: 
         body = await parse_json_body(request)
         if not body:
@@ -161,7 +161,7 @@ async def handle_signin(request: Any, env: Any, path_params: Dict[str, str], que
             return error_response("JWT secret not configured, please configure it using `wrangler secret put JWT_SECRET`", 500)
         method = str(request.method).upper()
         if method != "POST":
-            return error_response("Method Not Allowed", 404)
+            return error_response("Method Not Allowed", 405)
         body = await parse_json_body(request)
         if not body:
             return error_response("Invalid JSON body", 400) 
@@ -237,7 +237,7 @@ async def handle_verify_email(request: Any, env: Any, path_params: Dict[str, str
 
         method = str(request.method).upper()
         if method != "GET":
-            return error_response("Method Not Allowed", 404)
+            return error_response("Method Not Allowed", 405)
         
         # Get token from query parameters (e.g., ?token=xxx)
         token = query_params.get("token")

--- a/src/handlers/auth.py
+++ b/src/handlers/auth.py
@@ -156,12 +156,12 @@ async def handle_signin(request: Any, env: Any, path_params: Dict[str, str], que
     """
     logger = logging.getLogger(__name__)
     try:
-        jwt_secret = env.JWT_SECRET
-        if not jwt_secret:
-            return error_response("JWT secret not configured, please configure it using `wrangler secret put JWT_SECRET`", 500)
         method = str(request.method).upper()
         if method != "POST":
             return error_response("Method Not Allowed", 405, headers={"Allow": "POST"})
+        jwt_secret = env.JWT_SECRET
+        if not jwt_secret:
+            return error_response("JWT secret not configured, please configure it using `wrangler secret put JWT_SECRET`", 500)
         body = await parse_json_body(request)
         if not body:
             return error_response("Invalid JSON body", 400) 
@@ -229,15 +229,13 @@ async def handle_verify_email(request: Any, env: Any, path_params: Dict[str, str
     """ 
     logger = logging.getLogger(__name__)   
     try:
-        db= await  get_db_safe(env)
-        jwt_secret = env.JWT_SECRET
-
-        if not jwt_secret:
-            return error_response("JWT secret not configured, please configure it using `wrangler secret put JWT_SECRET`", 500)
-
         method = str(request.method).upper()
         if method != "GET":
             return error_response("Method Not Allowed", 405, headers={"Allow": "GET"})
+        db= await  get_db_safe(env)
+        jwt_secret = env.JWT_SECRET
+        if not jwt_secret:
+            return error_response("JWT secret not configured, please configure it using `wrangler secret put JWT_SECRET`", 500)
         
         # Get token from query parameters (e.g., ?token=xxx)
         token = query_params.get("token")

--- a/src/handlers/auth.py
+++ b/src/handlers/auth.py
@@ -69,7 +69,7 @@ async def handle_signup(
     method = str(request.method).upper()
     logger = logging.getLogger(__name__)
     if method != "POST":
-        return error_response( "Method Not Allowed", 405)
+        return error_response("Method Not Allowed", 405, headers={"Allow": "POST"})
     try: 
         body = await parse_json_body(request)
         if not body:
@@ -161,7 +161,7 @@ async def handle_signin(request: Any, env: Any, path_params: Dict[str, str], que
             return error_response("JWT secret not configured, please configure it using `wrangler secret put JWT_SECRET`", 500)
         method = str(request.method).upper()
         if method != "POST":
-            return error_response("Method Not Allowed", 405)
+            return error_response("Method Not Allowed", 405, headers={"Allow": "POST"})
         body = await parse_json_body(request)
         if not body:
             return error_response("Invalid JSON body", 400) 
@@ -237,7 +237,7 @@ async def handle_verify_email(request: Any, env: Any, path_params: Dict[str, str
 
         method = str(request.method).upper()
         if method != "GET":
-            return error_response("Method Not Allowed", 405)
+            return error_response("Method Not Allowed", 405, headers={"Allow": "GET"})
         
         # Get token from query parameters (e.g., ?token=xxx)
         token = query_params.get("token")

--- a/src/handlers/auth.py
+++ b/src/handlers/auth.py
@@ -159,9 +159,11 @@ async def handle_signin(request: Any, env: Any, path_params: Dict[str, str], que
         method = str(request.method).upper()
         if method != "POST":
             return error_response("Method Not Allowed", 405, headers={"Allow": "POST"})
+
         jwt_secret = env.JWT_SECRET
         if not jwt_secret:
             return error_response("JWT secret not configured, please configure it using `wrangler secret put JWT_SECRET`", 500)
+
         body = await parse_json_body(request)
         if not body:
             return error_response("Invalid JSON body", 400) 
@@ -232,8 +234,10 @@ async def handle_verify_email(request: Any, env: Any, path_params: Dict[str, str
         method = str(request.method).upper()
         if method != "GET":
             return error_response("Method Not Allowed", 405, headers={"Allow": "GET"})
-        db= await  get_db_safe(env)
+
+        db = await get_db_safe(env)
         jwt_secret = env.JWT_SECRET
+
         if not jwt_secret:
             return error_response("JWT secret not configured, please configure it using `wrangler secret put JWT_SECRET`", 500)
         

--- a/src/utils.py
+++ b/src/utils.py
@@ -89,16 +89,18 @@ def json_response(
 def error_response(
     message: str,
     status: int = 400,
-    details: Optional[Dict[str, Any]] = None
+    details: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None
 ) -> Response:
     """
     Create an error JSON response.
-    
+
     Args:
         message: Error message
         status: HTTP status code
         details: Additional error details
-    
+        headers: Additional headers to include
+
     Returns:
         Response object with error information
     """
@@ -107,11 +109,11 @@ def error_response(
         "message": message,
         "status": status
     }
-    
+
     if details:
         error_data["details"] = details
-    
-    return json_response(error_data, status=status)
+
+    return json_response(error_data, status=status, headers=headers)
 
 
 def success_response(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,17 +1,11 @@
 """Tests for auth handler method guards."""
 
+import importlib.util
 import sys
 import types
 from pathlib import Path
 
 import pytest
-
-# Make src and src/handlers importable without triggering package side effects.
-src_path = Path(__file__).resolve().parent.parent / "src"
-handlers_path = src_path / "handlers"
-sys.path.insert(0, str(src_path))
-sys.path.insert(0, str(handlers_path))
-
 
 class _MockWorkersResponse:
     @staticmethod
@@ -19,10 +13,22 @@ class _MockWorkersResponse:
         return types.SimpleNamespace(body=data, status=status, headers=headers or {})
 
 
-# Stub workers module required by handlers/auth.py imports.
-sys.modules.setdefault("workers", types.SimpleNamespace(Response=_MockWorkersResponse))
+@pytest.fixture
+def auth_handler_module(monkeypatch):
+    """Load handlers/auth.py with an isolated workers stub per test."""
+    monkeypatch.setitem(
+        sys.modules,
+        "workers",
+        types.SimpleNamespace(Response=_MockWorkersResponse),
+    )
 
-import auth as auth_handler  # pyright: ignore[reportMissingImports]
+    module_path = Path(__file__).resolve().parent.parent / "src" / "handlers" / "auth.py"
+    spec = importlib.util.spec_from_file_location("auth_handler_under_test", module_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class MockRequest:
@@ -39,25 +45,49 @@ class EmptyEnv:
 
 
 @pytest.mark.asyncio
-async def test_signin_wrong_method_returns_405_before_jwt_check():
+async def test_signin_wrong_method_returns_405_before_jwt_check(auth_handler_module):
     request = MockRequest(method="GET")
-    response = await auth_handler.handle_signin(request, EmptyEnv(), {}, {}, "/auth/signin")
+    response = await auth_handler_module.handle_signin(
+        request, EmptyEnv(), {}, {}, "/auth/signin"
+    )
 
     assert response.status == 405
     assert response.headers.get("Allow") == "POST"
 
 
 @pytest.mark.asyncio
-async def test_verify_email_wrong_method_returns_405_before_db_or_jwt(monkeypatch):
+async def test_verify_email_wrong_method_returns_405_before_db_or_jwt(
+    monkeypatch,
+    auth_handler_module,
+):
     async def _boom_get_db(_env):
         raise AssertionError("get_db_safe should not be called for wrong method")
 
-    monkeypatch.setattr(auth_handler, "get_db_safe", _boom_get_db)
+    monkeypatch.setattr(auth_handler_module, "get_db_safe", _boom_get_db)
 
     request = MockRequest(method="POST", url="https://example.com/auth/verify-email")
-    response = await auth_handler.handle_verify_email(
+    response = await auth_handler_module.handle_verify_email(
         request, EmptyEnv(), {}, {}, "/auth/verify-email"
     )
 
     assert response.status == 405
     assert response.headers.get("Allow") == "GET"
+
+
+@pytest.mark.asyncio
+async def test_signup_wrong_method_returns_405_before_db_or_jwt(
+    monkeypatch,
+    auth_handler_module,
+):
+    async def _boom_get_db(_env):
+        raise AssertionError("get_db_safe should not be called for wrong method")
+
+    monkeypatch.setattr(auth_handler_module, "get_db_safe", _boom_get_db)
+
+    request = MockRequest(method="GET", url="https://example.com/auth/signup")
+    response = await auth_handler_module.handle_signup(
+        request, EmptyEnv(), {}, {}, "/auth/signup"
+    )
+
+    assert response.status == 405
+    assert response.headers.get("Allow") == "POST"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,63 @@
+"""Tests for auth handler method guards."""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Make src and src/handlers importable without triggering package side effects.
+src_path = Path(__file__).resolve().parent.parent / "src"
+handlers_path = src_path / "handlers"
+sys.path.insert(0, str(src_path))
+sys.path.insert(0, str(handlers_path))
+
+
+class _MockWorkersResponse:
+    @staticmethod
+    def json(data, status=200, headers=None):
+        return types.SimpleNamespace(body=data, status=status, headers=headers or {})
+
+
+# Stub workers module required by handlers/auth.py imports.
+sys.modules.setdefault("workers", types.SimpleNamespace(Response=_MockWorkersResponse))
+
+import auth as auth_handler  # pyright: ignore[reportMissingImports]
+
+
+class MockRequest:
+    def __init__(self, method: str, url: str = "https://example.com/auth/signin"):
+        self.method = method
+        self.url = url
+
+    async def text(self):
+        return ""
+
+
+class EmptyEnv:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_signin_wrong_method_returns_405_before_jwt_check():
+    request = MockRequest(method="GET")
+    response = await auth_handler.handle_signin(request, EmptyEnv(), {}, {}, "/auth/signin")
+
+    assert response.status == 405
+    assert response.headers.get("Allow") == "POST"
+
+
+@pytest.mark.asyncio
+async def test_verify_email_wrong_method_returns_405_before_db_or_jwt(monkeypatch):
+    async def _boom_get_db(_env):
+        raise AssertionError("get_db_safe should not be called for wrong method")
+
+    monkeypatch.setattr(auth_handler, "get_db_safe", _boom_get_db)
+
+    request = MockRequest(method="POST", url="https://example.com/auth/verify-email")
+    response = await auth_handler.handle_verify_email(
+        request, EmptyEnv(), {}, {}, "/auth/verify-email"
+    )
+
+    assert response.status == 405
+    assert response.headers.get("Allow") == "GET"


### PR DESCRIPTION
## Summary
Fixes auth endpoint method handling so unsupported methods return 405 Method Not Allowed (with Allow) instead of 404, and adds focused regression tests.

## Problem
Auth endpoints returned 404 Not Found for non-allowed methods, which is semantically incorrect and inconsistent with HTTP method handling.

## Fix
- Ensured wrong-method requests return 405 Method Not Allowed with Allow header.
- Kept early method validation flow for auth handlers.
- Added dedicated tests to verify early method-guard behavior:
  - handle_signup returns 405 before DB setup.
  - handle_signin returns 405 before JWT checks.
  - handle_verify_email returns 405 before DB/JWT setup.
- Resolved merge conflicts with upstream while preserving the above behavior.

## Files Changed
- auth.py — auth method-guard flow updates
- test_auth.py — focused regression tests
- utils.py — conflict-resolution docstring formatting alignment

## Testing
- Ran: test_auth.py
- Result: 3 passed
- Verified wrong-method requests return 405 with correct Allow header and fail fast before deeper setup