### PR TITLE
fix(bugs): prevent unauthenticated mass-assignment in POST /bugs

### DIFF
--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -193,25 +193,35 @@ async def handle_bugs(
                 status=400
             )
 
-        # Prevent clients from setting security-sensitive fields.
-        privileged_fields = ["verified", "user", "closed_by", "reporter_ip_address"]
-        provided_privileged_fields = [field for field in privileged_fields if field in body]
-        if provided_privileged_fields:
-            return error_response(
-                "The following fields are server-managed and cannot be set: "
-                + ", ".join(provided_privileged_fields),
-                status=400
-            )
+        # Positive allowlist: only copy keys clients are allowed to write.
+        client_writable_fields = {
+            "url",
+            "description",
+            "markdown_description",
+            "label",
+            "score",
+            "user_agent",
+            "ocr",
+            "screenshot",
+            "github_url",
+            "cve_id",
+            "cve_score",
+            "hunt",
+            "domain",
+        }
+        sanitized_body = {k: v for k, v in body.items() if k in client_writable_fields}
+
+        url = body["url"]
         
         
         # Validate URL length
-        if len(body["url"]) > 200:
+        if len(url) > 200:
             return error_response("URL must be 200 characters or less", status=400)
 
         # Validate URL format and protocol
         try:
             from urllib.parse import urlparse
-            parsed = urlparse(body["url"])
+            parsed = urlparse(url)
             if parsed.scheme not in ("http", "https"):
                 return error_response(
                     "URL must use http or https protocol",
@@ -234,6 +244,17 @@ async def handle_bugs(
                 except Exception:
                     reporter_ip = None
 
+            # Server-side identity (if an auth layer attaches one to request).
+            user_id = None
+            if hasattr(request, "user_id"):
+                user_id = getattr(request, "user_id")
+            elif hasattr(request, "user"):
+                request_user = getattr(request, "user")
+                if isinstance(request_user, dict):
+                    user_id = request_user.get("id")
+                else:
+                    user_id = getattr(request_user, "id", None)
+
             # Insert the new bug - use None for NULL values
             result = await db.prepare('''
                 INSERT INTO bugs (
@@ -243,26 +264,26 @@ async def handle_bugs(
                     hunt, domain, user, closed_by
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''').bind(
-                body.get("url"),
-                body.get("description"),
-                body.get("markdown_description") or None,
-                body.get("label") or None,
-                body.get("views") or None,
+                sanitized_body.get("url"),
+                sanitized_body.get("description"),
+                sanitized_body.get("markdown_description") or None,
+                sanitized_body.get("label") or None,
                 0,
-                body.get("score") or None,
-                body.get("status") or "open",
-                body.get("user_agent") or None,
-                body.get("ocr") or None,
-                body.get("screenshot") or None,
-                body.get("github_url") or None,
-                1 if body.get("is_hidden") else 0,
-                body.get("rewarded") or 0,
+                0,
+                sanitized_body.get("score") or None,
+                "open",
+                sanitized_body.get("user_agent") or None,
+                sanitized_body.get("ocr") or None,
+                sanitized_body.get("screenshot") or None,
+                sanitized_body.get("github_url") or None,
+                0,
+                0,
                 reporter_ip,
-                body.get("cve_id") or None,
-                body.get("cve_score") or None,
-                body.get("hunt") or None,
-                body.get("domain") or None,
-                None,
+                sanitized_body.get("cve_id") or None,
+                sanitized_body.get("cve_score") or None,
+                sanitized_body.get("hunt") or None,
+                sanitized_body.get("domain") or None,
+                user_id,
                 None
             ).run()
             

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -250,6 +250,16 @@ async def handle_bugs(
         except Exception:
             return error_response("Invalid URL format", status=400)
         
+        # Validate description
+        description = sanitized_body.get("description")
+        
+        if not isinstance(description, str):
+            return error_response("Description must be a string", status=400)
+        
+        description = description.strip()
+        if not description:
+            return error_response("Description is required", status=400)
+        
         try:
             # Use a trusted edge header when available; never accept this from JSON body.
             reporter_ip = None
@@ -279,25 +289,25 @@ async def handle_bugs(
                     hunt, domain, user, closed_by
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''').bind(
-                sanitized_body.get("url"),
-                sanitized_body.get("description"),
-                sanitized_body.get("markdown_description") or None,
-                sanitized_body.get("label") or None,
+                url,
+                description,
+                sanitized_body.get("markdown_description") if "markdown_description" in sanitized_body else None,
+                sanitized_body.get("label") if "label" in sanitized_body else None,
                 0,
                 0,
-                sanitized_body.get("score") or None,
+                sanitized_body.get("score") if "score" in sanitized_body else None,
                 "open",
-                sanitized_body.get("user_agent") or None,
-                sanitized_body.get("ocr") or None,
-                sanitized_body.get("screenshot") or None,
-                sanitized_body.get("github_url") or None,
+                sanitized_body.get("user_agent") if "user_agent" in sanitized_body else None,
+                sanitized_body.get("ocr") if "ocr" in sanitized_body else None,
+                sanitized_body.get("screenshot") if "screenshot" in sanitized_body else None,
+                sanitized_body.get("github_url") if "github_url" in sanitized_body else None,
                 0,
                 0,
                 reporter_ip,
-                sanitized_body.get("cve_id") or None,
-                sanitized_body.get("cve_score") or None,
-                sanitized_body.get("hunt") or None,
-                sanitized_body.get("domain") or None,
+                sanitized_body.get("cve_id") if "cve_id" in sanitized_body else None,
+                sanitized_body.get("cve_score") if "cve_score" in sanitized_body else None,
+                sanitized_body.get("hunt") if "hunt" in sanitized_body else None,
+                sanitized_body.get("domain") if "domain" in sanitized_body else None,
                 user_id,
                 None
             ).run()

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -192,6 +192,16 @@ async def handle_bugs(
                 f"Missing required fields: {', '.join(missing_fields)}",
                 status=400
             )
+
+        # Prevent clients from setting security-sensitive fields.
+        privileged_fields = ["verified", "user", "closed_by", "reporter_ip_address"]
+        provided_privileged_fields = [field for field in privileged_fields if field in body]
+        if provided_privileged_fields:
+            return error_response(
+                "The following fields are server-managed and cannot be set: "
+                + ", ".join(provided_privileged_fields),
+                status=400
+            )
         
         
         # Validate URL length
@@ -216,6 +226,14 @@ async def handle_bugs(
             return error_response("Invalid URL format", status=400)
         
         try:
+            # Use a trusted edge header when available; never accept this from JSON body.
+            reporter_ip = None
+            if hasattr(request, "headers") and request.headers:
+                try:
+                    reporter_ip = request.headers.get("CF-Connecting-IP")
+                except Exception:
+                    reporter_ip = None
+
             # Insert the new bug - use None for NULL values
             result = await db.prepare('''
                 INSERT INTO bugs (
@@ -230,7 +248,7 @@ async def handle_bugs(
                 body.get("markdown_description") or None,
                 body.get("label") or None,
                 body.get("views") or None,
-                1 if body.get("verified") else 0,
+                0,
                 body.get("score") or None,
                 body.get("status") or "open",
                 body.get("user_agent") or None,
@@ -239,13 +257,13 @@ async def handle_bugs(
                 body.get("github_url") or None,
                 1 if body.get("is_hidden") else 0,
                 body.get("rewarded") or 0,
-                body.get("reporter_ip_address") or None,
+                reporter_ip,
                 body.get("cve_id") or None,
                 body.get("cve_score") or None,
                 body.get("hunt") or None,
                 body.get("domain") or None,
-                body.get("user") or None,
-                body.get("closed_by") or None
+                None,
+                None
             ).run()
             
             # Get the last inserted row ID

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -209,9 +209,24 @@ async def handle_bugs(
             "hunt",
             "domain",
         }
+
+        forbidden = sorted(set(body.keys()) - client_writable_fields)
+        if forbidden:
+            return error_response(
+                "The following fields are not allowed: " + ", ".join(forbidden),
+                status=400,
+            )
+
         sanitized_body = {k: v for k, v in body.items() if k in client_writable_fields}
 
-        url = body["url"]
+        url = sanitized_body.get("url")
+
+        if not isinstance(url, str):
+            return error_response("URL must be a string", status=400)
+
+        url = url.strip()
+        if not url:
+            return error_response("URL is required", status=400)
         
         
         # Validate URL length

--- a/tests/test_bugs_security.py
+++ b/tests/test_bugs_security.py
@@ -20,37 +20,39 @@ class MockEnv:
     pass
 
 
+class FakeStatement:
+    def __init__(self, db, sql):
+        self._db = db
+        self._sql = sql
+        self._params = ()
+
+    def bind(self, *params):
+        self._params = params
+        return self
+
+    async def run(self):
+        if "INSERT INTO bugs" in self._sql:
+            self._db.insert_params = self._params
+        return None
+
+    async def first(self):
+        if "last_insert_rowid()" in self._sql:
+            return {"id": 1}
+        if "SELECT * FROM bugs WHERE id = ?" in self._sql:
+            return {"id": 1, "url": "https://example.com/vuln", "description": "test"}
+        return None
+
+
+class FakeDB:
+    def __init__(self):
+        self.insert_params = None
+
+    def prepare(self, sql):
+        return FakeStatement(self, sql)
+
+
 @pytest.mark.asyncio
-async def test_create_bug_uses_allowlist_and_server_defaults(monkeypatch):
-    class FakeStatement:
-        def __init__(self, db, sql):
-            self._db = db
-            self._sql = sql
-            self._params = ()
-
-        def bind(self, *params):
-            self._params = params
-            return self
-
-        async def run(self):
-            if "INSERT INTO bugs" in self._sql:
-                self._db.insert_params = self._params
-            return None
-
-        async def first(self):
-            if "last_insert_rowid()" in self._sql:
-                return {"id": 1}
-            if "SELECT * FROM bugs WHERE id = ?" in self._sql:
-                return {"id": 1, "url": "https://example.com/vuln", "description": "test"}
-            return None
-
-    class FakeDB:
-        def __init__(self):
-            self.insert_params = None
-
-        def prepare(self, sql):
-            return FakeStatement(self, sql)
-
+async def test_create_bug_rejects_forbidden_fields(monkeypatch):
     fake_db = FakeDB()
 
     async def _fake_get_db_safe(_env):
@@ -83,6 +85,41 @@ async def test_create_bug_uses_allowlist_and_server_defaults(monkeypatch):
         path="/bugs",
     )
 
+    assert getattr(response, "status", None) == 400
+    payload = json.loads(response.body)
+    assert payload["error"] is True
+    assert "The following fields are not allowed" in payload["message"]
+    assert "verified" in payload["message"]
+    assert "views" in payload["message"]
+    assert fake_db.insert_params is None
+
+
+@pytest.mark.asyncio
+async def test_create_bug_uses_allowlist_and_server_defaults(monkeypatch):
+    fake_db = FakeDB()
+
+    async def _fake_get_db_safe(_env):
+        return fake_db
+
+    monkeypatch.setattr(bugs_handler, "get_db_safe", _fake_get_db_safe)
+
+    request_body = json.dumps(
+        {
+            "url": "https://example.com/vuln",
+            "description": "test",
+            "score": 10,
+            "domain": 3,
+        }
+    )
+
+    response = await bugs_handler.handle_bugs(
+        request=MockRequest(request_body, headers={"CF-Connecting-IP": "8.8.8.8"}),
+        env=MockEnv(),
+        path_params={},
+        query_params={},
+        path="/bugs",
+    )
+
     assert getattr(response, "status", None) == 201
     payload = json.loads(response.body)
     assert payload["success"] is True
@@ -100,3 +137,65 @@ async def test_create_bug_uses_allowlist_and_server_defaults(monkeypatch):
     assert fake_db.insert_params[18] == 3  # domain (allowlisted)
     assert fake_db.insert_params[19] is None  # user (no auth user in request)
     assert fake_db.insert_params[20] is None  # closed_by
+
+
+@pytest.mark.asyncio
+async def test_create_bug_rejects_non_string_url(monkeypatch):
+    fake_db = FakeDB()
+
+    async def _fake_get_db_safe(_env):
+        return fake_db
+
+    monkeypatch.setattr(bugs_handler, "get_db_safe", _fake_get_db_safe)
+
+    request_body = json.dumps(
+        {
+            "url": 123,
+            "description": "test",
+        }
+    )
+
+    response = await bugs_handler.handle_bugs(
+        request=MockRequest(request_body, headers={"CF-Connecting-IP": "8.8.8.8"}),
+        env=MockEnv(),
+        path_params={},
+        query_params={},
+        path="/bugs",
+    )
+
+    assert getattr(response, "status", None) == 400
+    payload = json.loads(response.body)
+    assert payload["error"] is True
+    assert payload["message"] == "URL must be a string"
+    assert fake_db.insert_params is None
+
+
+@pytest.mark.asyncio
+async def test_create_bug_rejects_blank_url(monkeypatch):
+    fake_db = FakeDB()
+
+    async def _fake_get_db_safe(_env):
+        return fake_db
+
+    monkeypatch.setattr(bugs_handler, "get_db_safe", _fake_get_db_safe)
+
+    request_body = json.dumps(
+        {
+            "url": "   ",
+            "description": "test",
+        }
+    )
+
+    response = await bugs_handler.handle_bugs(
+        request=MockRequest(request_body, headers={"CF-Connecting-IP": "8.8.8.8"}),
+        env=MockEnv(),
+        path_params={},
+        query_params={},
+        path="/bugs",
+    )
+
+    assert getattr(response, "status", None) == 400
+    payload = json.loads(response.body)
+    assert payload["error"] is True
+    assert payload["message"] == "URL is required"
+    assert fake_db.insert_params is None

--- a/tests/test_bugs_security.py
+++ b/tests/test_bugs_security.py
@@ -21,9 +21,40 @@ class MockEnv:
 
 
 @pytest.mark.asyncio
-async def test_create_bug_rejects_privileged_fields(monkeypatch):
+async def test_create_bug_uses_allowlist_and_server_defaults(monkeypatch):
+    class FakeStatement:
+        def __init__(self, db, sql):
+            self._db = db
+            self._sql = sql
+            self._params = ()
+
+        def bind(self, *params):
+            self._params = params
+            return self
+
+        async def run(self):
+            if "INSERT INTO bugs" in self._sql:
+                self._db.insert_params = self._params
+            return None
+
+        async def first(self):
+            if "last_insert_rowid()" in self._sql:
+                return {"id": 1}
+            if "SELECT * FROM bugs WHERE id = ?" in self._sql:
+                return {"id": 1, "url": "https://example.com/vuln", "description": "test"}
+            return None
+
+    class FakeDB:
+        def __init__(self):
+            self.insert_params = None
+
+        def prepare(self, sql):
+            return FakeStatement(self, sql)
+
+    fake_db = FakeDB()
+
     async def _fake_get_db_safe(_env):
-        return object()
+        return fake_db
 
     monkeypatch.setattr(bugs_handler, "get_db_safe", _fake_get_db_safe)
 
@@ -31,22 +62,41 @@ async def test_create_bug_rejects_privileged_fields(monkeypatch):
         {
             "url": "https://example.com/vuln",
             "description": "test",
+            "score": 10,
+            "domain": 3,
             "verified": True,
             "user": 10,
             "closed_by": 20,
             "reporter_ip_address": "1.2.3.4",
+            "views": 999,
+            "status": "closed",
+            "is_hidden": 1,
+            "rewarded": 123,
         }
     )
 
     response = await bugs_handler.handle_bugs(
-        request=MockRequest(request_body),
+        request=MockRequest(request_body, headers={"CF-Connecting-IP": "8.8.8.8"}),
         env=MockEnv(),
         path_params={},
         query_params={},
         path="/bugs",
     )
 
-    assert getattr(response, "status", None) == 400
+    assert getattr(response, "status", None) == 201
     payload = json.loads(response.body)
-    assert payload["error"] is True
-    assert "server-managed" in payload["message"]
+    assert payload["success"] is True
+
+    assert fake_db.insert_params is not None
+
+    # Server-managed defaults are enforced, regardless of user input.
+    assert fake_db.insert_params[4] == 0  # views
+    assert fake_db.insert_params[5] == 0  # verified
+    assert fake_db.insert_params[6] == 10  # score (allowlisted)
+    assert fake_db.insert_params[7] == "open"  # status
+    assert fake_db.insert_params[12] == 0  # is_hidden
+    assert fake_db.insert_params[13] == 0  # rewarded
+    assert fake_db.insert_params[14] == "8.8.8.8"  # reporter_ip_address
+    assert fake_db.insert_params[18] == 3  # domain (allowlisted)
+    assert fake_db.insert_params[19] is None  # user (no auth user in request)
+    assert fake_db.insert_params[20] is None  # closed_by

--- a/tests/test_bugs_security.py
+++ b/tests/test_bugs_security.py
@@ -1,0 +1,52 @@
+"""Security-focused tests for bug creation handler."""
+
+import json
+import pytest
+
+from handlers import bugs as bugs_handler
+
+
+class MockRequest:
+    def __init__(self, body, method="POST", headers=None):
+        self.method = method
+        self._body = body
+        self.headers = headers or {}
+
+    async def text(self):
+        return self._body
+
+
+class MockEnv:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_create_bug_rejects_privileged_fields(monkeypatch):
+    async def _fake_get_db_safe(_env):
+        return object()
+
+    monkeypatch.setattr(bugs_handler, "get_db_safe", _fake_get_db_safe)
+
+    request_body = json.dumps(
+        {
+            "url": "https://example.com/vuln",
+            "description": "test",
+            "verified": True,
+            "user": 10,
+            "closed_by": 20,
+            "reporter_ip_address": "1.2.3.4",
+        }
+    )
+
+    response = await bugs_handler.handle_bugs(
+        request=MockRequest(request_body),
+        env=MockEnv(),
+        path_params={},
+        query_params={},
+        path="/bugs",
+    )
+
+    assert getattr(response, "status", None) == 400
+    payload = json.loads(response.body)
+    assert payload["error"] is True
+    assert "server-managed" in payload["message"]

--- a/tests/test_bugs_security.py
+++ b/tests/test_bugs_security.py
@@ -199,3 +199,65 @@ async def test_create_bug_rejects_blank_url(monkeypatch):
     assert payload["error"] is True
     assert payload["message"] == "URL is required"
     assert fake_db.insert_params is None
+
+
+@pytest.mark.asyncio
+async def test_create_bug_rejects_non_string_description(monkeypatch):
+    fake_db = FakeDB()
+
+    async def _fake_get_db_safe(_env):
+        return fake_db
+
+    monkeypatch.setattr(bugs_handler, "get_db_safe", _fake_get_db_safe)
+
+    request_body = json.dumps(
+        {
+            "url": "https://example.com/vuln",
+            "description": 123,
+        }
+    )
+
+    response = await bugs_handler.handle_bugs(
+        request=MockRequest(request_body, headers={"CF-Connecting-IP": "8.8.8.8"}),
+        env=MockEnv(),
+        path_params={},
+        query_params={},
+        path="/bugs",
+    )
+
+    assert getattr(response, "status", None) == 400
+    payload = json.loads(response.body)
+    assert payload["error"] is True
+    assert payload["message"] == "Description must be a string"
+    assert fake_db.insert_params is None
+
+
+@pytest.mark.asyncio
+async def test_create_bug_rejects_blank_description(monkeypatch):
+    fake_db = FakeDB()
+
+    async def _fake_get_db_safe(_env):
+        return fake_db
+
+    monkeypatch.setattr(bugs_handler, "get_db_safe", _fake_get_db_safe)
+
+    request_body = json.dumps(
+        {
+            "url": "https://example.com/vuln",
+            "description": "   ",
+        }
+    )
+
+    response = await bugs_handler.handle_bugs(
+        request=MockRequest(request_body, headers={"CF-Connecting-IP": "8.8.8.8"}),
+        env=MockEnv(),
+        path_params={},
+        query_params={},
+        path="/bugs",
+    )
+
+    assert getattr(response, "status", None) == 400
+    payload = json.loads(response.body)
+    assert payload["error"] is True
+    assert payload["message"] == "Description is required"
+    assert fake_db.insert_params is None


### PR DESCRIPTION
### Summary

This PR fixes a security issue in POST /bugs where clients could set
server-managed fields directly via the request body.

Affected fields:
- verified
- user
- closed_by
- reporter_ip_address

Requests containing these fields are now rejected with HTTP 400 and the
values are controlled exclusively by the server.

A regression test has been added to ensure these fields cannot be set
via the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced server-controlled fields on bug creation; extraneous client fields are rejected with 400 and a list of forbidden fields.
  * Added request-body sanitization and stricter URL/description validation (trim, non-empty, length, scheme, domain).
  * Server now captures reporter IP and resolves user identity; inserts use sanitized and server-derived values with sensible defaults.

* **Tests**
  * Added security tests for forbidden-field rejection, URL/description validation, and successful creation with server-managed defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->