### PR TITLE
fix: URL-decode query parameters in _parse_query_params

### DIFF
--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -59,41 +59,38 @@ async def handle_bugs(
         except ValueError:
             limit_int = 10
         
-        try:
-            search_result = await db.prepare('''
-                SELECT 
-                    b.id,
-                    b.url,
-                    b.description,
-                    b.status,   
-                    b.verified,
-                    b.score,
-                    b.views,    
-                    b.created,
-                    b.modified,
-                    b.is_hidden,
-                    b.rewarded, 
-                    b.cve_id,
-                    b.cve_score,    
-                    b.domain,
-                    d.name as domain_name,
-                    d.url as domain_url 
-                FROM bugs b   
-                LEFT JOIN domains d ON b.domain = d.id
-                WHERE b.url LIKE ? OR b.description LIKE ?
-                ORDER BY b.created DESC
-                LIMIT ? OFFSET 0
-            ''').bind(f"%{query}%", f"%{query}%", limit_int).all()
-            
-            response_data = convert_d1_results(search_result.results if hasattr(search_result, 'results') else [])
-            return Response.json({
-                "success": True,
-                "query": query,
-                "data": response_data
-            })
-        except Exception as e:
-            logger.error(f"Error searching bugs: {str(e)}")
-            return error_response(f"Failed to search bugs: {str(e)}", status=500)
+        search_result = await db.prepare('''
+            SELECT 
+                b.id,
+                b.url,
+                b.description,
+                b.status,   
+                b.verified,
+                b.score,
+                b.views,    
+                b.created,
+                b.modified,
+                b.is_hidden,
+                b.rewarded, 
+                b.cve_id,
+                b.cve_score,    
+                b.domain,
+                d.name as domain_name,
+                d.url as domain_url 
+            FROM bugs b   
+            LEFT JOIN domains d ON b.domain = d.id
+            WHERE b.url LIKE ? OR b.description LIKE ?
+            ORDER BY b.created DESC
+            LIMIT ? OFFSET 0
+        ''').bind(f"%{query}%", f"%{query}%", limit_int).all()
+        
+        response_data = convert_d1_results(search_result.results if hasattr(search_result, 'results') else [])
+        return Response.json({
+            "success": True,
+            "query": query,
+            "data": response_data
+        })
+    
     # Get specific bug
     if "id" in path_params:
         try:
@@ -102,86 +99,82 @@ async def handle_bugs(
             logger.warning(f"Invalid bug id format: {path_params['id']}")
             return error_response("Invalid bug id format", status=400)
 
-        try:
-            result = await db.prepare('''
-                SELECT 
-                    b.id,
-                    b.url,
-                    b.description,
-                    b.markdown_description,
-                    b.label,
-                    b.views,
-                    b.verified,
-                    b.score,
-                    b.status,
-                    b.user_agent,
-                    b.ocr,
-                    b.screenshot,
-                    b.closed_date,
-                    b.github_url,
-                    b.created,
-                    b.modified,
-                    b.is_hidden,
-                    b.rewarded,
-                    b.reporter_ip_address,
-                    b.cve_id,
-                    b.cve_score,
-                    b.hunt,
-                    b.domain,
-                    b.user,
-                    b.closed_by,
-                    d.id as domain_id,
-                    d.name as domain_name,
-                    d.url as domain_url,
-                    d.logo as domain_logo
-                FROM bugs b
-                LEFT JOIN domains d ON b.domain = d.id
-                WHERE b.id = ?
-            ''').bind(bug_id).first()
-            
-            # Convert JsProxy result directly to Python dict
-            if result and hasattr(result, 'to_py'):
-                bug_data = result.to_py()
-            elif result and isinstance(result, dict):
-                bug_data = dict(result)
-            else:
-                bug_data = None
-            
-            if not bug_data:
-                return error_response("Bug not found", status=404)
-            
-            # Get screenshots for this bug
-            screenshots_result = await db.prepare('''
-                SELECT id, image, created
-                FROM bug_screenshots
-                WHERE bug = ?
-                ORDER BY created DESC
-            ''').bind(bug_id).all()
-            
-            # Get tags for this bug
-            tags_result = await db.prepare('''
-                SELECT t.id, t.name
-                FROM bug_tags bt
-                JOIN tags t ON bt.tag_id = t.id
-                WHERE bt.bug_id = ?
-                ORDER BY t.name
-            ''').bind(bug_id).all()
-            
-            # Convert results
-            screenshots_data = convert_d1_results(screenshots_result.results if hasattr(screenshots_result, 'results') else [])
-            tags_data = convert_d1_results(tags_result.results if hasattr(tags_result, 'results') else [])
-            
-            # Add screenshots and tags to bug data
-            bug_data['screenshots'] = screenshots_data
-            bug_data['tags'] = tags_data
-            
-            return Response.json({
-                "success": True,
-                "data": bug_data
-            })
-        except Exception as e:
-            logger.error(f"Error fetching bug {bug_id}: {str(e)}")
-            return error_response(f"Failed to fetch bug: {str(e)}", status=500)
+        result = await db.prepare('''
+            SELECT 
+                b.id,
+                b.url,
+                b.description,
+                b.markdown_description,
+                b.label,
+                b.views,
+                b.verified,
+                b.score,
+                b.status,
+                b.user_agent,
+                b.ocr,
+                b.screenshot,
+                b.closed_date,
+                b.github_url,
+                b.created,
+                b.modified,
+                b.is_hidden,
+                b.rewarded,
+                b.reporter_ip_address,
+                b.cve_id,
+                b.cve_score,
+                b.hunt,
+                b.domain,
+                b.user,
+                b.closed_by,
+                d.id as domain_id,
+                d.name as domain_name,
+                d.url as domain_url,
+                d.logo as domain_logo
+            FROM bugs b
+            LEFT JOIN domains d ON b.domain = d.id
+            WHERE b.id = ?
+        ''').bind(bug_id).first()
+        
+        # Convert JsProxy result directly to Python dict
+        if result and hasattr(result, 'to_py'):
+            bug_data = result.to_py()
+        elif result and isinstance(result, dict):
+            bug_data = dict(result)
+        else:
+            bug_data = None
+        
+        if not bug_data:
+            return error_response("Bug not found", status=404)
+        
+        # Get screenshots for this bug
+        screenshots_result = await db.prepare('''
+            SELECT id, image, created
+            FROM bug_screenshots
+            WHERE bug = ?
+            ORDER BY created DESC
+        ''').bind(bug_id).all()
+        
+        # Get tags for this bug
+        tags_result = await db.prepare('''
+            SELECT t.id, t.name
+            FROM bug_tags bt
+            JOIN tags t ON bt.tag_id = t.id
+            WHERE bt.bug_id = ?
+            ORDER BY t.name
+        ''').bind(bug_id).all()
+        
+        # Convert results
+        screenshots_data = convert_d1_results(screenshots_result.results if hasattr(screenshots_result, 'results') else [])
+        tags_data = convert_d1_results(tags_result.results if hasattr(tags_result, 'results') else [])
+        
+        # Add screenshots and tags to bug data
+        bug_data['screenshots'] = screenshots_data
+        bug_data['tags'] = tags_data
+        
+        return Response.json({
+            "success": True,
+            "data": bug_data
+        })
     
     # Create bug
     if method == "POST":

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -59,38 +59,41 @@ async def handle_bugs(
         except ValueError:
             limit_int = 10
         
-        search_result = await db.prepare('''
-            SELECT 
-                b.id,
-                b.url,
-                b.description,
-                b.status,   
-                b.verified,
-                b.score,
-                b.views,    
-                b.created,
-                b.modified,
-                b.is_hidden,
-                b.rewarded, 
-                b.cve_id,
-                b.cve_score,    
-                b.domain,
-                d.name as domain_name,
-                d.url as domain_url 
-            FROM bugs b   
-            LEFT JOIN domains d ON b.domain = d.id
-            WHERE b.url LIKE ? OR b.description LIKE ?
-            ORDER BY b.created DESC
-            LIMIT ? OFFSET 0
-        ''').bind(f"%{query}%", f"%{query}%", limit_int).all()
-        
-        response_data = convert_d1_results(search_result.results if hasattr(search_result, 'results') else [])
-        return Response.json({
-            "success": True,
-            "query": query,
-            "data": response_data
-        })
-    
+        try:
+            search_result = await db.prepare('''
+                SELECT 
+                    b.id,
+                    b.url,
+                    b.description,
+                    b.status,   
+                    b.verified,
+                    b.score,
+                    b.views,    
+                    b.created,
+                    b.modified,
+                    b.is_hidden,
+                    b.rewarded, 
+                    b.cve_id,
+                    b.cve_score,    
+                    b.domain,
+                    d.name as domain_name,
+                    d.url as domain_url 
+                FROM bugs b   
+                LEFT JOIN domains d ON b.domain = d.id
+                WHERE b.url LIKE ? OR b.description LIKE ?
+                ORDER BY b.created DESC
+                LIMIT ? OFFSET 0
+            ''').bind(f"%{query}%", f"%{query}%", limit_int).all()
+            
+            response_data = convert_d1_results(search_result.results if hasattr(search_result, 'results') else [])
+            return Response.json({
+                "success": True,
+                "query": query,
+                "data": response_data
+            })
+        except Exception as e:
+            logger.error(f"Error searching bugs: {str(e)}")
+            return error_response(f"Failed to search bugs: {str(e)}", status=500)
     # Get specific bug
     if "id" in path_params:
         try:
@@ -99,82 +102,86 @@ async def handle_bugs(
             logger.warning(f"Invalid bug id format: {path_params['id']}")
             return error_response("Invalid bug id format", status=400)
 
-        result = await db.prepare('''
-            SELECT 
-                b.id,
-                b.url,
-                b.description,
-                b.markdown_description,
-                b.label,
-                b.views,
-                b.verified,
-                b.score,
-                b.status,
-                b.user_agent,
-                b.ocr,
-                b.screenshot,
-                b.closed_date,
-                b.github_url,
-                b.created,
-                b.modified,
-                b.is_hidden,
-                b.rewarded,
-                b.reporter_ip_address,
-                b.cve_id,
-                b.cve_score,
-                b.hunt,
-                b.domain,
-                b.user,
-                b.closed_by,
-                d.id as domain_id,
-                d.name as domain_name,
-                d.url as domain_url,
-                d.logo as domain_logo
-            FROM bugs b
-            LEFT JOIN domains d ON b.domain = d.id
-            WHERE b.id = ?
-        ''').bind(bug_id).first()
-        
-        # Convert JsProxy result directly to Python dict
-        if result and hasattr(result, 'to_py'):
-            bug_data = result.to_py()
-        elif result and isinstance(result, dict):
-            bug_data = dict(result)
-        else:
-            bug_data = None
-        
-        if not bug_data:
-            return error_response("Bug not found", status=404)
-        
-        # Get screenshots for this bug
-        screenshots_result = await db.prepare('''
-            SELECT id, image, created
-            FROM bug_screenshots
-            WHERE bug = ?
-            ORDER BY created DESC
-        ''').bind(bug_id).all()
-        
-        # Get tags for this bug
-        tags_result = await db.prepare('''
-            SELECT t.id, t.name
-            FROM bug_tags bt
-            JOIN tags t ON bt.tag_id = t.id
-            WHERE bt.bug_id = ?
-            ORDER BY t.name
-        ''').bind(bug_id).all()
-        
-        # Convert results
-        screenshots_data = convert_d1_results(screenshots_result.results if hasattr(screenshots_result, 'results') else [])
-        tags_data = convert_d1_results(tags_result.results if hasattr(tags_result, 'results') else [])
-        
-        # Add screenshots and tags to bug data
-        bug_data['screenshots'] = screenshots_data
-        bug_data['tags'] = tags_data
-        
-        return Response.json({
-            "success": True,
-            "data": bug_data
-        })
+        try:
+            result = await db.prepare('''
+                SELECT 
+                    b.id,
+                    b.url,
+                    b.description,
+                    b.markdown_description,
+                    b.label,
+                    b.views,
+                    b.verified,
+                    b.score,
+                    b.status,
+                    b.user_agent,
+                    b.ocr,
+                    b.screenshot,
+                    b.closed_date,
+                    b.github_url,
+                    b.created,
+                    b.modified,
+                    b.is_hidden,
+                    b.rewarded,
+                    b.reporter_ip_address,
+                    b.cve_id,
+                    b.cve_score,
+                    b.hunt,
+                    b.domain,
+                    b.user,
+                    b.closed_by,
+                    d.id as domain_id,
+                    d.name as domain_name,
+                    d.url as domain_url,
+                    d.logo as domain_logo
+                FROM bugs b
+                LEFT JOIN domains d ON b.domain = d.id
+                WHERE b.id = ?
+            ''').bind(bug_id).first()
+            
+            # Convert JsProxy result directly to Python dict
+            if result and hasattr(result, 'to_py'):
+                bug_data = result.to_py()
+            elif result and isinstance(result, dict):
+                bug_data = dict(result)
+            else:
+                bug_data = None
+            
+            if not bug_data:
+                return error_response("Bug not found", status=404)
+            
+            # Get screenshots for this bug
+            screenshots_result = await db.prepare('''
+                SELECT id, image, created
+                FROM bug_screenshots
+                WHERE bug = ?
+                ORDER BY created DESC
+            ''').bind(bug_id).all()
+            
+            # Get tags for this bug
+            tags_result = await db.prepare('''
+                SELECT t.id, t.name
+                FROM bug_tags bt
+                JOIN tags t ON bt.tag_id = t.id
+                WHERE bt.bug_id = ?
+                ORDER BY t.name
+            ''').bind(bug_id).all()
+            
+            # Convert results
+            screenshots_data = convert_d1_results(screenshots_result.results if hasattr(screenshots_result, 'results') else [])
+            tags_data = convert_d1_results(tags_result.results if hasattr(tags_result, 'results') else [])
+            
+            # Add screenshots and tags to bug data
+            bug_data['screenshots'] = screenshots_data
+            bug_data['tags'] = tags_data
+            
+            return Response.json({
+                "success": True,
+                "data": bug_data
+            })
+        except Exception as e:
+            logger.error(f"Error fetching bug {bug_id}: {str(e)}")
+            return error_response(f"Failed to fetch bug: {str(e)}", status=500)
     
     # Create bug
     if method == "POST":

--- a/src/router.py
+++ b/src/router.py
@@ -6,6 +6,7 @@ path parameters and different HTTP methods.
 """
 
 import re
+from urllib.parse import parse_qs, urlparse
 from typing import Callable, Dict, List, Optional, Tuple, Any
 from utils import error_response, json_response
 
@@ -136,15 +137,9 @@ class Router:
         return path
     
     def _parse_query_params(self, url: str) -> Dict[str, str]:
-        """Parse query parameters from URL."""
-        params = {}
-        if "?" in url:
-            query_string = url.split("?", 1)[1]
-            for pair in query_string.split("&"):
-                if "=" in pair:
-                    key, value = pair.split("=", 1)
-                    params[key] = value
-        return params
+        """Parse query parameters from URL, decoding percent-encoded and plus-encoded values."""
+        query_string = urlparse(url).query
+        return {k: v[0] for k, v in parse_qs(query_string).items()}
     
     async def handle(self, request: Any, env: Any) -> Any:
         """

--- a/src/router.py
+++ b/src/router.py
@@ -139,7 +139,7 @@ class Router:
     def _parse_query_params(self, url: str) -> Dict[str, str]:
         """Parse query parameters from URL, decoding percent-encoded and plus-encoded values."""
         query_string = urlparse(url).query
-        return {k: v[0] for k, v in parse_qs(query_string).items()}
+        return {k: v[0] for k, v in parse_qs(query_string, keep_blank_values=True).items()}
     
     async def handle(self, request: Any, env: Any) -> Any:
         """

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -112,6 +112,22 @@ class TestRouter:
         params = router._parse_query_params("/users")
         assert params == {}
 
+    def test_parse_query_params_url_encoded(self):
+        """Test that query parameters are URL-decoded."""
+        router = Router()
+
+        # Plus-encoded spaces
+        params = router._parse_query_params("/bugs/search?q=sql+injection")
+        assert params == {"q": "sql injection"}
+
+        # Percent-encoded characters
+        params = router._parse_query_params("/bugs/search?q=hello%20world&domain=example%2Ecom")
+        assert params == {"q": "hello world", "domain": "example.com"}
+
+        # Mixed encoding
+        params = router._parse_query_params("/bugs/search?status=open&q=cross-site+scripting%20%28XSS%29")
+        assert params == {"status": "open", "q": "cross-site scripting (XSS)"}
+
 
 class TestRouterDecorators:
     """Tests for router decorator methods."""

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -132,9 +132,9 @@ class TestRouter:
         params = router._parse_query_params("/bugs?status=&page=1")
         assert params == {"status": "", "page": "1"}
 
-        # Duplicate keys - last value wins
+        # Duplicate keys: first value wins (v[0] from parse_qs list)
         params = router._parse_query_params("/bugs?tag=xss&tag=sqli")
-        assert "tag" in params
+        assert params == {"tag": "xss"}
 
 
 class TestRouterDecorators:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -128,6 +128,14 @@ class TestRouter:
         params = router._parse_query_params("/bugs/search?status=open&q=cross-site+scripting%20%28XSS%29")
         assert params == {"status": "open", "q": "cross-site scripting (XSS)"}
 
+        # Blank values are preserved
+        params = router._parse_query_params("/bugs?status=&page=1")
+        assert params == {"status": "", "page": "1"}
+
+        # Duplicate keys - last value wins
+        params = router._parse_query_params("/bugs?tag=xss&tag=sqli")
+        assert "tag" in params
+
 
 class TestRouterDecorators:
     """Tests for router decorator methods."""


### PR DESCRIPTION
## Problem
`_parse_query_params()` in `src/router.py` stored raw undecoded values.
A request like `/bugs/search?q=sql+injection` would pass `"sql+injection"` 
to handlers instead of `"sql injection"`, causing LIKE queries to match 
nothing. No URL decoding existed anywhere else in the pipeline.

## Fix
Replaced manual string splitting with `urllib.parse.parse_qs` and 
`urlparse` which correctly handle percent-encoding and plus-encoding.

## Tests
Added `test_parse_query_params_url_encoded` covering plus-encoding, 
percent-encoding, and mixed encoding cases.

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query parameter parsing so URL-encoded values (percent-encoding and plus-encoding) are properly decoded, preserving blank values and consistently selecting the first value for duplicate keys.

* **Tests**
  * Added test coverage validating decoding of URL-encoded query parameters, blank-value preservation, and duplicate-key handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->