### PR TITLE
fix: add logging and genericize error responses in domains handler

### DIFF
--- a/src/handlers/domains.py
+++ b/src/handlers/domains.py
@@ -3,10 +3,13 @@ Domains handler for the BLT API.
 """
 
 from typing import Any, Dict
+import logging
 from utils import error_response, parse_pagination_params, convert_d1_results
 from libs.db import get_db_safe
 from workers import Response
 from models import Domain
+
+logger = logging.getLogger(__name__)
 
 
 async def handle_domains(
@@ -38,7 +41,8 @@ async def handle_domains(
     try:
         db = await get_db_safe(env)
     except Exception as e:
-        return error_response(str(e), status=503)
+        logger.error(f"Database connection error: {str(e)}")
+        return error_response("Database connection failed", status=503)
 
     # Get specific domain
     if "id" in path_params:
@@ -79,9 +83,9 @@ async def handle_domains(
                     }
                 })
             except Exception as e:
-                return error_response(
-                    f"Failed to fetch domain tags: {str(e)}", status=500
-                )
+                logger.error(f"Failed to fetch domain tags: {str(e)}")
+                return error_response("Failed to fetch domain tags", status=500)
+
 
         # GET /domains/{id}
         try:
@@ -91,7 +95,8 @@ async def handle_domains(
 
             return Response.json({"success": True, "data": domain})
         except Exception as e:
-            return error_response(f"Failed to fetch domain: {str(e)}", status=500)
+            logger.error(f"Failed to fetch domain: {str(e)}")
+            return error_response("Failed to fetch domain", status=500)
 
     # GET /domains  –  list with pagination
     try:
@@ -117,4 +122,5 @@ async def handle_domains(
             }
         })
     except Exception as e:
-        return error_response(f"Failed to fetch domains: {str(e)}", status=500)
+        logger.error(f"Failed to fetch domains: {str(e)}")
+        return error_response("Failed to fetch domains", status=500)

--- a/src/handlers/domains.py
+++ b/src/handlers/domains.py
@@ -41,7 +41,7 @@ async def handle_domains(
     try:
         db = await get_db_safe(env)
     except Exception as e:
-        logger.error(f"Database connection error: {str(e)}")
+        logger.error(f"Database connection error: {e!s}", exc_info=True)
         return error_response("Database connection failed", status=503)
 
     # Get specific domain
@@ -83,7 +83,7 @@ async def handle_domains(
                     }
                 })
             except Exception as e:
-                logger.error(f"Failed to fetch domain tags: {str(e)}")
+                logger.error(f"Failed to fetch domain tags: {e!s}", exc_info=True)
                 return error_response("Failed to fetch domain tags", status=500)
 
 
@@ -95,7 +95,7 @@ async def handle_domains(
 
             return Response.json({"success": True, "data": domain})
         except Exception as e:
-            logger.error(f"Failed to fetch domain: {str(e)}")
+            logger.error(f"Failed to fetch domain: {e!s}", exc_info=True)
             return error_response("Failed to fetch domain", status=500)
 
     # GET /domains  –  list with pagination
@@ -122,5 +122,5 @@ async def handle_domains(
             }
         })
     except Exception as e:
-        logger.error(f"Failed to fetch domains: {str(e)}")
+        logger.error(f"Failed to fetch domains: {e!s}", exc_info=True)
         return error_response("Failed to fetch domains", status=500)


### PR DESCRIPTION
## Problem
In `src/handlers/domains.py`, all four error responses exposed raw 
exception details to clients via str(e), and there was no logging 
at all making production debugging impossible:

    return error_response(str(e), status=503)
    return error_response(f"Failed to fetch domain tags: {str(e)}", status=500)
    return error_response(f"Failed to fetch domain: {str(e)}", status=500)
    return error_response(f"Failed to fetch domains: {str(e)}", status=500)

## Fix
- Added logging import and logger instance
- Full exception details logged server-side via logger.error()
- Generic messages returned to clients
- Consistent with pattern applied in organizations handler (PR #50)

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error responses for domain- and database-related failures to provide clearer, consistent messages to users.
  * Added unobtrusive server-side logging for domain endpoints so errors are recorded for diagnostics while original HTTP status codes are preserved.
  * Expanded error handling across domain operations to ensure consistent behavior and clearer feedback when failures occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->