### PR TITLE
fix: sanitize error responses and add logging in domains handler

### DIFF
--- a/src/handlers/domains.py
+++ b/src/handlers/domains.py
@@ -2,11 +2,14 @@
 Domains handler for the BLT API.
 """
 
+import logging
 from typing import Any, Dict
 from utils import error_response, parse_pagination_params, convert_d1_results
 from libs.db import get_db_safe
 from workers import Response
 from models import Domain
+
+logger = logging.getLogger(__name__)
 
 
 async def handle_domains(
@@ -38,7 +41,8 @@ async def handle_domains(
     try:
         db = await get_db_safe(env)
     except Exception as e:
-        return error_response(str(e), status=503)
+        logger.error("Database connection failed: %s", e, exc_info=True)
+        return error_response("Service temporarily unavailable", status=503)
 
     # Get specific domain
     if "id" in path_params:
@@ -79,9 +83,8 @@ async def handle_domains(
                     }
                 })
             except Exception as e:
-                return error_response(
-                    f"Failed to fetch domain tags: {str(e)}", status=500
-                )
+                logger.error("Failed to fetch tags for domain %s: %s", domain_id, e, exc_info=True)
+                return error_response("Failed to fetch domain tags", status=500)
 
         # GET /domains/{id}
         try:
@@ -91,7 +94,8 @@ async def handle_domains(
 
             return Response.json({"success": True, "data": domain})
         except Exception as e:
-            return error_response(f"Failed to fetch domain: {str(e)}", status=500)
+            logger.error("Failed to fetch domain %s: %s", domain_id, e, exc_info=True)
+            return error_response("Failed to fetch domain", status=500)
 
     # GET /domains  –  list with pagination
     try:
@@ -117,4 +121,5 @@ async def handle_domains(
             }
         })
     except Exception as e:
-        return error_response(f"Failed to fetch domains: {str(e)}", status=500)
+        logger.error("Failed to fetch domains: %s", e, exc_info=True)
+        return error_response("Failed to fetch domains", status=500)


### PR DESCRIPTION
## Summary

Fixes #52 — Raw exception details were exposed to API clients via `str(e)` in all 4 error paths in `src/handlers/domains.py`, and there was no logging at all.

## Changes

- Added `import logging` and `logger = logging.getLogger(__name__)`
- Replaced 4 instances of `str(e)` in error responses with generic messages
- Added `logger.error()` with `exc_info=True` for full server-side tracebacks
- DB connection failure now returns 503 with "Service temporarily unavailable"

## Test plan

- [ ] `GET /domains` returns generic error on DB failure, not stack trace
- [ ] `GET /domains/{id}` returns generic error on failure
- [ ] `GET /domains/{id}/tags` returns generic error on failure
- [ ] Server logs still contain full exception details for debugging

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for domain operations with clearer, user-friendly error messages instead of technical exception details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->