### PR TITLE
feat: add script to generate Postman collection from API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,8 @@ python scripts/generate_postman_collection.py \
    | `password` | `s3cr3t` | Plain text |
    | `token` | *(leave blank)* | Auto-populated by the sign-in request |
 
+  The signup request auto-generates `signup_username`, `signup_password`, and `signup_email` in a pre-request script, so you do not need to set them manually.
+
 3. Select the environment and run the collection. The first request (`POST /auth/signin`) stores the JWT in `token`; every subsequent request sends `Authorization: Bearer {{token}}` automatically.
 
 #### Built-in tests

--- a/README.md
+++ b/README.md
@@ -544,6 +544,78 @@ BLT-API/
 └── README.md
 ```
 
+### Postman Collection
+
+A script is provided to generate a ready-to-use Postman Collection v2.1 from
+the live route definitions in `src/main.py`. No running server is needed.
+
+#### Generate the collection
+
+```bash
+# Write blt_api_postman_collection.json to the project root (default)
+python scripts/generate_postman_collection.py
+
+# Write to a custom path
+python scripts/generate_postman_collection.py --output ~/Desktop/blt.json
+
+# Lower the response-time threshold in generated tests to 3 s
+python scripts/generate_postman_collection.py --response-time-ms 3000
+```
+
+#### Custom execution order
+
+```bash
+# List all valid endpoint ids first
+python scripts/generate_postman_collection.py --list-endpoints
+
+# Prioritise specific endpoints (login must always be first)
+python scripts/generate_postman_collection.py \
+    --order post_auth_signin get_health get_bugs post_bugs
+```
+
+#### Import into Postman
+
+1. Open Postman → **Import** → select `blt_api_postman_collection.json`.
+2. Create a new **Environment** and set these four variables:
+
+   | Variable | Example value | Notes |
+   |----------|---------------|-------|
+   | `base_url` | `http://localhost:8787` | No trailing slash |
+   | `username` | `alice` | Must be an active account |
+   | `password` | `s3cr3t` | Plain text |
+   | `token` | *(leave blank)* | Auto-populated by the sign-in request |
+
+3. Select the environment and run the collection. The first request (`POST /auth/signin`) stores the JWT in `token`; every subsequent request sends `Authorization: Bearer {{token}}` automatically.
+
+#### Built-in tests
+
+Every generated request includes:
+
+- **Status code** assertion (200, 201, etc.).
+- **Response time** assertion (default threshold: 5 000 ms).
+- **Valid JSON** assertion (response body is a non-null object).
+
+The sign-in request additionally validates that `token` is present and non-empty in the response body.
+
+> **Note — endpoints without pre-filled parameters**
+>
+> Only a subset of endpoints ship with pre-filled request bodies and query
+> parameters (see the table in the script docstring). For all other endpoints
+> you **must** open the request in Postman and manually add any required
+> parameters before running the collection:
+>
+> - **Path parameters** — replace the placeholder `1` in URLs like
+>   `/bugs/1` with a real resource id.
+> - **Query parameters** — add any required query params (e.g. `?q=...`)
+>   via the *Params* tab.
+> - **Body fields** — fill in required JSON fields in the *Body* tab.
+>
+> Sending a request with missing required parameters will produce a
+> `400 Bad Request` or `404 Not Found` response and cause the built-in
+> Postman tests to fail.
+
+---
+
 ### Adding New Endpoints
 
 1. Create a new handler in `src/handlers/`

--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ python scripts/generate_postman_collection.py \
 
   The signup request auto-generates `signup_username`, `signup_password`, and `signup_email` in a pre-request script, so you do not need to set them manually.
 
-3. Select the environment and run the collection. The first request (`POST /auth/signin`) stores the JWT in `token`; every subsequent request sends `Authorization: Bearer {{token}}` automatically.
+3. Select the environment and run the collection. The first request (`POST /auth/signin`) stores the auth token in `token`; every subsequent request sends `Authorization: Token {{token}}` automatically.
 
 #### Built-in tests
 

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -250,45 +250,52 @@ def discover_routes(main_file: Path = MAIN_FILE) -> list[EndpointDefinition]:
     tree = ast.parse(main_file.read_text(), filename=str(main_file))
     routes: list[EndpointDefinition] = []
 
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        if not isinstance(node.func, ast.Attribute):
-            continue
-        if node.func.attr != "add_route":
-            continue
-        if not isinstance(node.func.value, ast.Name) or node.func.value.id != "router":
-            continue
-        if len(node.args) < 3:
-            continue
+    def iter_nodes_in_source_order(node: ast.AST) -> Iterable[ast.AST]:
+        """Yield AST nodes via deterministic DFS while preserving source order."""
+        for child in ast.iter_child_nodes(node):
+            yield child
+            yield from iter_nodes_in_source_order(child)
 
-        method_node, path_node, handler_node = node.args[:3]
-        if not isinstance(method_node, ast.Constant) or not isinstance(method_node.value, str):
-            continue
-        if not isinstance(path_node, ast.Constant) or not isinstance(path_node.value, str):
-            continue
-        if not isinstance(handler_node, ast.Name):
-            continue
+    for statement in tree.body:
+        for node in iter_nodes_in_source_order(statement):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "add_route":
+                continue
+            if not isinstance(node.func.value, ast.Name) or node.func.value.id != "router":
+                continue
+            if len(node.args) < 3:
+                continue
 
-        method = method_node.value.upper()
-        path = path_node.value
-        handler = handler_node.id
+            method_node, path_node, handler_node = node.args[:3]
+            if not isinstance(method_node, ast.Constant) or not isinstance(method_node.value, str):
+                continue
+            if not isinstance(path_node, ast.Constant) or not isinstance(path_node.value, str):
+                continue
+            if not isinstance(handler_node, ast.Name):
+                continue
 
-        if path == "/" or handler == "handle_homepage":
-            continue
+            method = method_node.value.upper()
+            path = path_node.value
+            handler = handler_node.id
 
-        routes.append(
-            EndpointDefinition(
-                endpoint_id=build_endpoint_id(method, path),
-                method=method,
-                path=path,
-                handler=handler,
-                expected_status=EXPECTED_STATUS_OVERRIDES.get((method, path), 200),
-                folder=classify_folder(path),
-                query_params=QUERY_PARAM_SAMPLES.get((method, path), ()),
-                body=BODY_SAMPLES.get((method, path)),
+            if path == "/" or handler == "handle_homepage":
+                continue
+
+            routes.append(
+                EndpointDefinition(
+                    endpoint_id=build_endpoint_id(method, path),
+                    method=method,
+                    path=path,
+                    handler=handler,
+                    expected_status=EXPECTED_STATUS_OVERRIDES.get((method, path), 200),
+                    folder=classify_folder(path),
+                    query_params=QUERY_PARAM_SAMPLES.get((method, path), ()),
+                    body=BODY_SAMPLES.get((method, path)),
+                )
             )
-        )
 
     return routes
 
@@ -543,11 +550,11 @@ def build_collection(
     
     Discovers all routes, reorders with login first, generates request items,
     and wraps them in a collection with metadata and environment setup info.
-    
+
     Args:
         ordered_ids: Optional list of endpoint IDs to prioritize in collection order.
         response_time_ms: Response time threshold for generated test assertions.
-    
+
     Returns:
         Dict representing a Postman Collection v2.1 (info, item).
     """
@@ -582,19 +589,32 @@ def build_collection(
 
 def save_collection(output_path: Path, collection: dict[str, Any]) -> None:
     """Write the Postman collection to a JSON file.
-    
+
     Serializes the collection to JSON with 2-space indentation and creates
     parent directories if needed. Writes with UTF-8 encoding for portability.
-    
+
     Args:
         output_path: Path where the collection JSON will be written.
         collection: Postman collection dict to serialize.
-    
+
     Raises:
         OSError: If file write fails after directory creation.
     """
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(collection, indent=2) + "\n", encoding="utf-8")
+
+
+def positive_int(value: str) -> int:
+    """Parse a CLI integer argument and ensure it is strictly positive."""
+    try:
+        parsed_value = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Must be a positive integer") from exc
+
+    if parsed_value <= 0:
+        raise argparse.ArgumentTypeError("Must be a positive integer")
+
+    return parsed_value
 
 
 def parse_args() -> argparse.Namespace:
@@ -623,7 +643,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--response-time-ms",
-        type=int,
+        type=positive_int,
         default=DEFAULT_RESPONSE_TIME_MS,
         help="Maximum allowed response time for generated Postman tests.",
     )

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -78,6 +78,10 @@ password      Password for that account
 token         Leave blank — populated automatically after sign-in
 ============  =======================================================
 
+The ``POST /auth/signup`` request auto-populates ``signup_username``,
+``signup_password``, and ``signup_email`` in a pre-request script, so you do
+not need to create them manually.
+
 
 Per-request Postman tests
 -------------------------
@@ -103,7 +107,7 @@ All other routes produce a Postman request item with sensible defaults. Sample
 request bodies and query parameters are provided for the following endpoints:
 
 * ``POST /auth/signin`` — ``{"username": "{{username}}", "password": "{{password}}"}"
-* ``POST /auth/signup`` — ``{"username", "email", "password"}``
+* ``POST /auth/signup`` — auto-populated ``signup_*`` variables for a fresh user
 * ``POST /bugs``        — ``{"url", "description", "status"}``
 * ``GET  /bugs``        — ``?page=1&per_page=20``
 * ``GET  /bugs/search`` — ``?q=sql+injection&limit=10``
@@ -137,7 +141,11 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 MAIN_FILE = PROJECT_ROOT / "src" / "main.py"
 DEFAULT_OUTPUT = PROJECT_ROOT / "blt_api_postman_collection.json"
 LOGIN_ENDPOINT_ID = "post_auth_signin"
+SIGNUP_ENDPOINT_ID = "post_auth_signup"
 DEFAULT_RESPONSE_TIME_MS = 5000
+SIGNUP_USERNAME_VARIABLE = "signup_username"
+SIGNUP_PASSWORD_VARIABLE = "signup_password"
+SIGNUP_EMAIL_VARIABLE = "signup_email"
 
 
 @dataclass(frozen=True)
@@ -173,9 +181,9 @@ BODY_SAMPLES = {
         "password": "{{password}}",
     },
     ("POST", "/auth/signup"): {
-        "username": "{{username}}",
-        "email": "{{username}}@example.com",
-        "password": "{{password}}",
+        "username": f"{{{{{SIGNUP_USERNAME_VARIABLE}}}}}",
+        "email": f"{{{{{SIGNUP_EMAIL_VARIABLE}}}}}",
+        "password": f"{{{{{SIGNUP_PASSWORD_VARIABLE}}}}}",
     },
     ("POST", "/bugs"): {
         "url": "https://example.com/vulnerability",
@@ -317,6 +325,37 @@ def build_postman_tests(endpoint: EndpointDefinition, response_time_ms: int) -> 
     return "\n".join(lines)
 
 
+def build_prerequest_script(endpoint: EndpointDefinition) -> str | None:
+    if endpoint.endpoint_id != SIGNUP_ENDPOINT_ID:
+        return None
+
+    return "\n".join(
+        [
+            'const baseUsername = pm.environment.get("username");',
+            'const basePassword = pm.environment.get("password");',
+            '',
+            'pm.test("Signup source credentials are configured", function () {',
+            '    pm.expect(baseUsername).to.be.a("string").and.not.empty;',
+            '    pm.expect(basePassword).to.be.a("string").and.not.empty;',
+            '});',
+            '',
+            'const signupRunId = Date.now().toString();',
+            (
+                f'pm.collectionVariables.set("{SIGNUP_USERNAME_VARIABLE}", '
+                '`${baseUsername}_signup_${signupRunId}`);'
+            ),
+            (
+                f'pm.collectionVariables.set("{SIGNUP_PASSWORD_VARIABLE}", '
+                '`${basePassword}_signup`);'
+            ),
+            (
+                f'pm.collectionVariables.set("{SIGNUP_EMAIL_VARIABLE}", '
+                '`${baseUsername}_signup_${signupRunId}@example.com`);'
+            ),
+        ]
+    )
+
+
 def build_url(endpoint: EndpointDefinition) -> str:
     path = substitute_path_params(endpoint.path)
     raw_url = f"{{{{base_url}}}}{path}"
@@ -347,17 +386,32 @@ def build_request_item(endpoint: EndpointDefinition, response_time_ms: int) -> d
             "options": {"raw": {"language": "json"}},
         }
 
-    return {
-        "name": endpoint.display_name,
-        "event": [
+    events = []
+    prerequest_script = build_prerequest_script(endpoint)
+    if prerequest_script is not None:
+        events.append(
             {
-                "listen": "test",
+                "listen": "prerequest",
                 "script": {
                     "type": "text/javascript",
-                    "exec": build_postman_tests(endpoint, response_time_ms).splitlines(),
+                    "exec": prerequest_script.splitlines(),
                 },
             }
-        ],
+        )
+
+    events.append(
+        {
+            "listen": "test",
+            "script": {
+                "type": "text/javascript",
+                "exec": build_postman_tests(endpoint, response_time_ms).splitlines(),
+            },
+        }
+    )
+
+    return {
+        "name": endpoint.display_name,
+        "event": events,
         "request": request,
         "response": [],
     }
@@ -385,6 +439,10 @@ def build_collection(
             "- username",
             "- password",
             "- token",
+            (
+                f"The signup request auto-populates {SIGNUP_USERNAME_VARIABLE}, "
+                f"{SIGNUP_PASSWORD_VARIABLE}, and {SIGNUP_EMAIL_VARIABLE} in a pre-request script."
+            ),
             f"The first request is {LOGIN_ENDPOINT_ID} and stores the JWT in pm.environment.set(\"token\", value).",
         ]
     )

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -61,7 +61,7 @@ Authentication flow
    via ``pm.environment.set("token", ...)``.
 4. Every other request automatically includes the header::
 
-       Authorization: Bearer {{token}}
+    Authorization: Token {{token}}
 
 
 Required Postman environment variables
@@ -368,7 +368,7 @@ def build_url(endpoint: EndpointDefinition) -> str:
 def build_request_item(endpoint: EndpointDefinition, response_time_ms: int) -> dict[str, Any]:
     headers = [{"key": "Accept", "value": "application/json"}]
     if endpoint.endpoint_id != LOGIN_ENDPOINT_ID:
-        headers.append({"key": "Authorization", "value": "Bearer {{token}}"})
+        headers.append({"key": "Authorization", "value": "Token {{token}}"})
     if endpoint.body is not None:
         headers.append({"key": "Content-Type", "value": "application/json"})
 
@@ -443,7 +443,7 @@ def build_collection(
                 f"The signup request auto-populates {SIGNUP_USERNAME_VARIABLE}, "
                 f"{SIGNUP_PASSWORD_VARIABLE}, and {SIGNUP_EMAIL_VARIABLE} in a pre-request script."
             ),
-            f"The first request is {LOGIN_ENDPOINT_ID} and stores the JWT in pm.environment.set(\"token\", value).",
+            f"The first request is {LOGIN_ENDPOINT_ID} and stores the auth token in pm.environment.set(\"token\", value).",
         ]
     )
 

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""
+generate_postman_collection.py
+==============================
+Generates a Postman Collection v2.1 for the BLT API project.
+
+The script parses ``src/main.py`` using the Python ``ast`` module to discover
+every registered route and turns each one into a Postman request item. No
+running server is required.
+
+
+Quick start
+-----------
+::
+
+    # Default: write blt_api_postman_collection.json to the project root
+    python scripts/generate_postman_collection.py
+
+    # Write to a custom path
+    python scripts/generate_postman_collection.py --output ~/Desktop/blt.json
+
+    # Print all discovered endpoint ids and exit (useful for --order)
+    python scripts/generate_postman_collection.py --list-endpoints
+
+    # Specify explicit execution order (login must be first)
+    python scripts/generate_postman_collection.py \\
+        --order post_auth_signin get_health get_bugs get_bugs_id
+
+    # Adjust the response-time threshold used in Postman tests
+    python scripts/generate_postman_collection.py --response-time-ms 3000
+
+
+CLI arguments
+-------------
+--output PATH
+    Destination file for the generated collection JSON.
+    Defaults to ``<project-root>/blt_api_postman_collection.json``.
+
+--order ID [ID ...]
+    Whitespace-separated list of endpoint ids that should appear **first** in
+    the collection, in the given order. The first id **must** be
+    ``post_auth_signin``. Any endpoints not listed are appended afterwards in
+    their original discovery order. Use ``--list-endpoints`` to see all valid
+    ids.
+
+--response-time-ms MS
+    Upper bound (in milliseconds) for the ``Response time`` Postman test that
+    is added to every request. Defaults to ``5000``.
+
+--list-endpoints
+    Print ``<endpoint_id>: METHOD /path`` for every discovered route and exit.
+    Nothing is written to disk.
+
+
+Authentication flow
+-------------------
+1. The first request in the collection is always ``POST /auth/signin``.
+2. Its body uses the ``{{username}}`` and ``{{password}}`` environment
+   variables so you never have to hard-code credentials.
+3. The test script for that request extracts ``response.token`` and stores it
+   via ``pm.environment.set("token", ...)``.
+4. Every other request automatically includes the header::
+
+       Authorization: Bearer {{token}}
+
+
+Required Postman environment variables
+--------------------------------------
+Create a Postman environment and set the four variables below before running
+the collection:
+
+============  =======================================================
+Variable      Description
+============  =======================================================
+base_url      Base URL of the API, e.g. ``http://localhost:8787``
+username      Username of an existing active BLT account
+password      Password for that account
+token         Leave blank — populated automatically after sign-in
+============  =======================================================
+
+
+Per-request Postman tests
+-------------------------
+Every generated request has three built-in Postman tests:
+
+* **Status code** — asserts the expected HTTP status (200, 201, …).
+* **Response time** — asserts the response arrived within --response-time-ms ms.
+* **Valid JSON** — parses the response body and asserts it is a non-null object.
+
+The sign-in request additionally asserts that the ``token`` field is present and
+non-empty in the response, and stores it in the environment.
+
+
+How route discovery works
+-------------------------
+At generation time the script reads ``src/main.py`` through Python's ``ast``
+module (no import, no code execution) and finds every call that matches::
+
+    router.add_route("METHOD", "/path", handler_function)
+
+The homepage route (``/``) is excluded because it returns HTML, not JSON.
+All other routes produce a Postman request item with sensible defaults. Sample
+request bodies and query parameters are provided for the following endpoints:
+
+* ``POST /auth/signin`` — ``{"username": "{{username}}", "password": "{{password}}"}"
+* ``POST /auth/signup`` — ``{"username", "email", "password"}``
+* ``POST /bugs``        — ``{"url", "description", "status"}``
+* ``GET  /bugs``        — ``?page=1&per_page=20``
+* ``GET  /bugs/search`` — ``?q=sql+injection&limit=10``
+* ``GET  /auth/verify-email`` — ``?token=sample-verification-token``
+
+
+.. note::
+    **Required parameters for endpoints without pre-filled samples**
+
+    Endpoints not listed above are generated with an empty request body and no
+    query parameters. Before running the collection in Postman you **must**
+    manually open each such request and supply any required path parameters
+    (e.g. replace the placeholder ``1`` in ``/bugs/1`` with a real id),
+    query parameters, or body fields that the endpoint expects. Sending a
+    request with missing required parameters will result in a ``400 Bad
+    Request`` or ``404 Not Found`` response and failed Postman tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+MAIN_FILE = PROJECT_ROOT / "src" / "main.py"
+DEFAULT_OUTPUT = PROJECT_ROOT / "blt_api_postman_collection.json"
+LOGIN_ENDPOINT_ID = "post_auth_signin"
+DEFAULT_RESPONSE_TIME_MS = 5000
+
+
+@dataclass(frozen=True)
+class EndpointDefinition:
+    endpoint_id: str
+    method: str
+    path: str
+    handler: str
+    expected_status: int
+    folder: str
+    query_params: tuple[tuple[str, str], ...] = ()
+    body: dict[str, Any] | None = None
+
+    @property
+    def display_name(self) -> str:
+        return f"{self.method} {self.path}"
+
+
+EXPECTED_STATUS_OVERRIDES = {
+    ("POST", "/auth/signup"): 201,
+    ("POST", "/bugs"): 201,
+}
+
+QUERY_PARAM_SAMPLES = {
+    ("GET", "/bugs"): (("page", "1"), ("per_page", "20")),
+    ("GET", "/bugs/search"): (("q", "sql injection"), ("limit", "10")),
+    ("GET", "/auth/verify-email"): (("token", "sample-verification-token"),),
+}
+
+BODY_SAMPLES = {
+    ("POST", "/auth/signin"): {
+        "username": "{{username}}",
+        "password": "{{password}}",
+    },
+    ("POST", "/auth/signup"): {
+        "username": "{{username}}",
+        "email": "{{username}}@example.com",
+        "password": "{{password}}",
+    },
+    ("POST", "/bugs"): {
+        "url": "https://example.com/vulnerability",
+        "description": "Bug report created from the generated Postman collection.",
+        "status": "open",
+    },
+}
+
+
+def build_endpoint_id(method: str, path: str) -> str:
+    normalized_path = re.sub(r"[^a-z0-9]+", "_", path.lower()).strip("_")
+    return f"{method.lower()}_{normalized_path or 'root'}"
+
+
+def classify_folder(path: str) -> str:
+    parts = [part for part in path.split("/") if part]
+    if not parts:
+        return "Misc"
+    return parts[0].replace("-", " ").title()
+
+
+def substitute_path_params(path: str) -> str:
+    return re.sub(r"\{[^}]+\}", "1", path)
+
+
+def discover_routes(main_file: Path = MAIN_FILE) -> list[EndpointDefinition]:
+    tree = ast.parse(main_file.read_text(), filename=str(main_file))
+    routes: list[EndpointDefinition] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "add_route":
+            continue
+        if not isinstance(node.func.value, ast.Name) or node.func.value.id != "router":
+            continue
+        if len(node.args) < 3:
+            continue
+
+        method_node, path_node, handler_node = node.args[:3]
+        if not isinstance(method_node, ast.Constant) or not isinstance(method_node.value, str):
+            continue
+        if not isinstance(path_node, ast.Constant) or not isinstance(path_node.value, str):
+            continue
+        if not isinstance(handler_node, ast.Name):
+            continue
+
+        method = method_node.value.upper()
+        path = path_node.value
+        handler = handler_node.id
+
+        if path == "/" or handler == "handle_homepage":
+            continue
+
+        routes.append(
+            EndpointDefinition(
+                endpoint_id=build_endpoint_id(method, path),
+                method=method,
+                path=path,
+                handler=handler,
+                expected_status=EXPECTED_STATUS_OVERRIDES.get((method, path), 200),
+                folder=classify_folder(path),
+                query_params=QUERY_PARAM_SAMPLES.get((method, path), ()),
+                body=BODY_SAMPLES.get((method, path)),
+            )
+        )
+
+    return routes
+
+
+def reorder_endpoints(
+    endpoints: Iterable[EndpointDefinition],
+    ordered_ids: list[str] | None = None,
+) -> list[EndpointDefinition]:
+    discovered = list(endpoints)
+    endpoint_map = {endpoint.endpoint_id: endpoint for endpoint in discovered}
+
+    if LOGIN_ENDPOINT_ID not in endpoint_map:
+        raise ValueError("The login endpoint POST /auth/signin was not discovered.")
+
+    if ordered_ids:
+        unknown_ids = [endpoint_id for endpoint_id in ordered_ids if endpoint_id not in endpoint_map]
+        if unknown_ids:
+            available = ", ".join(sorted(endpoint_map))
+            raise ValueError(
+                f"Unknown endpoint ids: {', '.join(unknown_ids)}. Available ids: {available}"
+            )
+        if ordered_ids[0] != LOGIN_ENDPOINT_ID:
+            raise ValueError(
+                f"The first endpoint must be {LOGIN_ENDPOINT_ID} to satisfy the auth flow."
+            )
+        deduped_order = list(dict.fromkeys(ordered_ids))
+    else:
+        deduped_order = [LOGIN_ENDPOINT_ID]
+
+    remaining = [
+        endpoint.endpoint_id
+        for endpoint in discovered
+        if endpoint.endpoint_id not in deduped_order
+    ]
+    final_order = deduped_order + remaining
+    return [endpoint_map[endpoint_id] for endpoint_id in final_order]
+
+
+def build_postman_tests(endpoint: EndpointDefinition, response_time_ms: int) -> str:
+    lines = [
+        f'pm.test("Status code is {endpoint.expected_status}", function () {{',
+        f"    pm.response.to.have.status({endpoint.expected_status});",
+        "});",
+        "",
+        f'pm.test("Response time is below {response_time_ms}ms", function () {{',
+        f"    pm.expect(pm.response.responseTime).to.be.below({response_time_ms});",
+        "});",
+        "",
+        'let responseJson = null;',
+        'pm.test("Response body is valid JSON", function () {',
+        "    pm.expect(function () {",
+        "        responseJson = pm.response.json();",
+        "    }).to.not.throw();",
+        "    pm.expect(responseJson).to.not.equal(null);",
+        '    pm.expect(typeof responseJson).to.eql("object");',
+        "});",
+    ]
+
+    if endpoint.endpoint_id == LOGIN_ENDPOINT_ID:
+        lines.extend(
+            [
+                "",
+                'pm.test("Authentication token is present", function () {',
+                '    pm.expect(responseJson).to.have.property("token");',
+                '    pm.expect(responseJson.token).to.be.a("string").and.not.empty;',
+                '    pm.environment.set("token", responseJson.token);',
+                "});",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def build_url(endpoint: EndpointDefinition) -> str:
+    path = substitute_path_params(endpoint.path)
+    raw_url = f"{{{{base_url}}}}{path}"
+    if endpoint.query_params:
+        query_string = "&".join(f"{key}={value}" for key, value in endpoint.query_params)
+        raw_url = f"{raw_url}?{query_string}"
+    return raw_url
+
+
+def build_request_item(endpoint: EndpointDefinition, response_time_ms: int) -> dict[str, Any]:
+    headers = [{"key": "Accept", "value": "application/json"}]
+    if endpoint.endpoint_id != LOGIN_ENDPOINT_ID:
+        headers.append({"key": "Authorization", "value": "Bearer {{token}}"})
+    if endpoint.body is not None:
+        headers.append({"key": "Content-Type", "value": "application/json"})
+
+    request: dict[str, Any] = {
+        "method": endpoint.method,
+        "header": headers,
+        "url": build_url(endpoint),
+        "description": f"Generated from {endpoint.method} {endpoint.path}",
+    }
+
+    if endpoint.body is not None:
+        request["body"] = {
+            "mode": "raw",
+            "raw": json.dumps(endpoint.body, indent=2),
+            "options": {"raw": {"language": "json"}},
+        }
+
+    return {
+        "name": endpoint.display_name,
+        "event": [
+            {
+                "listen": "test",
+                "script": {
+                    "type": "text/javascript",
+                    "exec": build_postman_tests(endpoint, response_time_ms).splitlines(),
+                },
+            }
+        ],
+        "request": request,
+        "response": [],
+    }
+
+
+def build_items(endpoints: Iterable[EndpointDefinition], response_time_ms: int) -> list[dict[str, Any]]:
+    return [
+        build_request_item(endpoint, response_time_ms)
+        for endpoint in endpoints
+    ]
+
+
+def build_collection(
+    ordered_ids: list[str] | None = None,
+    response_time_ms: int = DEFAULT_RESPONSE_TIME_MS,
+) -> dict[str, Any]:
+    routes = discover_routes()
+    ordered_endpoints = reorder_endpoints(routes, ordered_ids)
+
+    description = "\n".join(
+        [
+            "Generated Postman Collection v2.1 for the BLT API.",
+            "Required Postman environment variables:",
+            "- base_url",
+            "- username",
+            "- password",
+            "- token",
+            f"The first request is {LOGIN_ENDPOINT_ID} and stores the JWT in pm.environment.set(\"token\", value).",
+        ]
+    )
+
+    return {
+        "info": {
+            "name": "BLT API",
+            "description": description,
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        },
+        "item": build_items(ordered_endpoints, response_time_ms),
+    }
+
+
+def save_collection(output_path: Path, collection: dict[str, Any]) -> None:
+    output_path.write_text(json.dumps(collection, indent=2) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a Postman Collection v2.1 for the BLT API."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output collection path. Defaults to {DEFAULT_OUTPUT.name} in the project root.",
+    )
+    parser.add_argument(
+        "--order",
+        nargs="*",
+        default=None,
+        help=(
+            "Optional endpoint ids to prioritize. The first id must be "
+            f"{LOGIN_ENDPOINT_ID}. Use --list-endpoints to inspect valid ids."
+        ),
+    )
+    parser.add_argument(
+        "--response-time-ms",
+        type=int,
+        default=DEFAULT_RESPONSE_TIME_MS,
+        help="Maximum allowed response time for generated Postman tests.",
+    )
+    parser.add_argument(
+        "--list-endpoints",
+        action="store_true",
+        help="Print discovered endpoint ids and exit.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    endpoints = discover_routes()
+
+    if args.list_endpoints:
+        for endpoint in endpoints:
+            print(f"{endpoint.endpoint_id}: {endpoint.method} {endpoint.path}")
+        return 0
+
+    collection = build_collection(args.order, args.response_time_ms)
+    save_collection(args.output, collection)
+    print(f"Saved Postman collection to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -135,6 +135,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
+from urllib.parse import urlencode
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -194,11 +195,28 @@ BODY_SAMPLES = {
 
 
 def build_endpoint_id(method: str, path: str) -> str:
+    """Generate a unique endpoint identifier from HTTP method and path.
+    
+    Args:
+        method: HTTP method (e.g., "GET", "POST").
+        path: URL path (e.g., "/bugs/{id}").
+    
+    Returns:
+        Endpoint ID like "get_bugs_id" (lowercase method_normalized_path).
+    """
     normalized_path = re.sub(r"[^a-z0-9]+", "_", path.lower()).strip("_")
     return f"{method.lower()}_{normalized_path or 'root'}"
 
 
 def classify_folder(path: str) -> str:
+    """Classify endpoint path into a Postman collection folder name.
+    
+    Args:
+        path: URL path (e.g., "/bugs/search").
+    
+    Returns:
+        Folder name like "Bugs" derived from first path segment.
+    """
     parts = [part for part in path.split("/") if part]
     if not parts:
         return "Misc"
@@ -206,10 +224,29 @@ def classify_folder(path: str) -> str:
 
 
 def substitute_path_params(path: str) -> str:
+    """Replace path parameters with placeholder values for request examples.
+    
+    Args:
+        path: URL path with parameters like "/bugs/{id}".
+    
+    Returns:
+        Path with placeholders replaced, e.g., "/bugs/1".
+    """
     return re.sub(r"\{[^}]+\}", "1", path)
 
 
 def discover_routes(main_file: Path = MAIN_FILE) -> list[EndpointDefinition]:
+    """Discover all API routes by parsing main.py with the ast module.
+    
+    Scans the main.py file for router.add_route() calls and extracts method,
+    path, and handler information. Excludes the homepage route ("/").
+    
+    Args:
+        main_file: Path to main.py file (default: src/main.py).
+    
+    Returns:
+        List of EndpointDefinition objects with route metadata.
+    """
     tree = ast.parse(main_file.read_text(), filename=str(main_file))
     routes: list[EndpointDefinition] = []
 
@@ -260,6 +297,22 @@ def reorder_endpoints(
     endpoints: Iterable[EndpointDefinition],
     ordered_ids: list[str] | None = None,
 ) -> list[EndpointDefinition]:
+    """Reorder endpoints with login first, then optional custom order.
+    
+    The login endpoint (POST /auth/signin) is always placed first to satisfy
+    the API's authentication flow. Other endpoints can be prioritized via
+    ordered_ids; remaining endpoints are appended in discovery order.
+    
+    Args:
+        endpoints: All discovered endpoints.
+        ordered_ids: Optional list of endpoint IDs to prioritize (first must be login).
+    
+    Returns:
+        Reordered list with login first and optional custom ordering applied.
+    
+    Raises:
+        ValueError: If login endpoint not found or invalid ordered_ids provided.
+    """
     discovered = list(endpoints)
     endpoint_map = {endpoint.endpoint_id: endpoint for endpoint in discovered}
 
@@ -291,6 +344,19 @@ def reorder_endpoints(
 
 
 def build_postman_tests(endpoint: EndpointDefinition, response_time_ms: int) -> str:
+    """Generate Postman test script for an endpoint.
+    
+    Creates JavaScript code that runs after the request to validate status code,
+    response time, and JSON structure. For login endpoint, also validates and
+    extracts the authentication token.
+    
+    Args:
+        endpoint: Endpoint to generate tests for.
+        response_time_ms: Maximum allowed response time threshold.
+    
+    Returns:
+        JavaScript code as a multi-line string suitable for Postman test script.
+    """
     lines = [
         f'pm.test("Status code is {endpoint.expected_status}", function () {{',
         f"    pm.response.to.have.status({endpoint.expected_status});",
@@ -326,6 +392,18 @@ def build_postman_tests(endpoint: EndpointDefinition, response_time_ms: int) -> 
 
 
 def build_prerequest_script(endpoint: EndpointDefinition) -> str | None:
+    """Generate Postman pre-request script for signup endpoint.
+    
+    Creates JavaScript code that runs before signup request to populate
+    signup_username, signup_password, and signup_email with fresh values
+    derived from base credentials. Returns None for non-signup endpoints.
+    
+    Args:
+        endpoint: Endpoint to generate pre-request script for.
+    
+    Returns:
+        JavaScript code as a string for Postman pre-request script, or None.
+    """
     if endpoint.endpoint_id != SIGNUP_ENDPOINT_ID:
         return None
 
@@ -357,15 +435,39 @@ def build_prerequest_script(endpoint: EndpointDefinition) -> str | None:
 
 
 def build_url(endpoint: EndpointDefinition) -> str:
+    """Build a Postman request URL with properly encoded query parameters.
+    
+    Constructs the full URL using the {{base_url}} Postman variable, substitutes
+    path parameters with placeholders (e.g., {id} -> 1), and appends query
+    parameters with proper URL encoding via urllib.parse.urlencode.
+    
+    Args:
+        endpoint: Endpoint to build URL for.
+    
+    Returns:
+        URL string like "{{base_url}}/bugs?page=1&per_page=20".
+    """
     path = substitute_path_params(endpoint.path)
     raw_url = f"{{{{base_url}}}}{path}"
     if endpoint.query_params:
-        query_string = "&".join(f"{key}={value}" for key, value in endpoint.query_params)
-        raw_url = f"{raw_url}?{query_string}"
+        raw_url = f"{raw_url}?{urlencode(endpoint.query_params)}"
     return raw_url
 
 
 def build_request_item(endpoint: EndpointDefinition, response_time_ms: int) -> dict[str, Any]:
+    """Build a complete Postman request item for a single endpoint.
+    
+    Constructs a Postman request with headers, URL, body (if applicable),
+    pre-request script (for signup), and test script. Includes Authorization
+    header for non-login endpoints.
+    
+    Args:
+        endpoint: Endpoint to generate request item for.
+        response_time_ms: Response time threshold for test assertions.
+    
+    Returns:
+        Dict representing a Postman request item (name, event, request, response).
+    """
     headers = [{"key": "Accept", "value": "application/json"}]
     if endpoint.endpoint_id != LOGIN_ENDPOINT_ID:
         headers.append({"key": "Authorization", "value": "Token {{token}}"})
@@ -418,6 +520,15 @@ def build_request_item(endpoint: EndpointDefinition, response_time_ms: int) -> d
 
 
 def build_items(endpoints: Iterable[EndpointDefinition], response_time_ms: int) -> list[dict[str, Any]]:
+    """Build Postman request items for a collection of endpoints.
+    
+    Args:
+        endpoints: Endpoints to generate request items for.
+        response_time_ms: Response time threshold for test assertions.
+    
+    Returns:
+        List of Postman request items (one per endpoint).
+    """
     return [
         build_request_item(endpoint, response_time_ms)
         for endpoint in endpoints
@@ -428,6 +539,18 @@ def build_collection(
     ordered_ids: list[str] | None = None,
     response_time_ms: int = DEFAULT_RESPONSE_TIME_MS,
 ) -> dict[str, Any]:
+    """Build a complete Postman Collection v2.1 from discovered routes.
+    
+    Discovers all routes, reorders with login first, generates request items,
+    and wraps them in a collection with metadata and environment setup info.
+    
+    Args:
+        ordered_ids: Optional list of endpoint IDs to prioritize in collection order.
+        response_time_ms: Response time threshold for generated test assertions.
+    
+    Returns:
+        Dict representing a Postman Collection v2.1 (info, item).
+    """
     routes = discover_routes()
     ordered_endpoints = reorder_endpoints(routes, ordered_ids)
 
@@ -458,10 +581,28 @@ def build_collection(
 
 
 def save_collection(output_path: Path, collection: dict[str, Any]) -> None:
-    output_path.write_text(json.dumps(collection, indent=2) + "\n")
+    """Write the Postman collection to a JSON file.
+    
+    Serializes the collection to JSON with 2-space indentation and creates
+    parent directories if needed. Writes with UTF-8 encoding for portability.
+    
+    Args:
+        output_path: Path where the collection JSON will be written.
+        collection: Postman collection dict to serialize.
+    
+    Raises:
+        OSError: If file write fails after directory creation.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(collection, indent=2) + "\n", encoding="utf-8")
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the collection generator.
+    
+    Returns:
+        Namespace with attributes: output, order, response_time_ms, list_endpoints.
+    """
     parser = argparse.ArgumentParser(
         description="Generate a Postman Collection v2.1 for the BLT API."
     )
@@ -495,6 +636,11 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    """Main entry point: parse args, generate/save collection, or list endpoints.
+    
+    Returns:
+        Exit code (0 for success, 1 for errors).
+    """
     args = parse_args()
     endpoints = discover_routes()
 

--- a/src/handlers/__init__.py
+++ b/src/handlers/__init__.py
@@ -18,6 +18,7 @@ from .repos import handle_repos
 from .health import handle_health
 from .homepage import handle_homepage
 from .auth import handle_signup, handle_signin, handle_verify_email
+from .postman_collection import handle_postman_collection
 
 __all__ = [
     "handle_bugs",
@@ -35,4 +36,5 @@ __all__ = [
     "handle_signup",
     "handle_signin",
     "handle_verify_email",
+    "handle_postman_collection",
 ]

--- a/src/handlers/postman_collection.py
+++ b/src/handlers/postman_collection.py
@@ -1,0 +1,298 @@
+"""Postman collection download handler."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable
+from urllib.parse import urlencode
+
+from utils import error_response, json_response
+
+
+MAIN_FILE = Path(__file__).resolve().parents[1] / "main.py"
+DEFAULT_RESPONSE_TIME_MS = 5000
+LOGIN_ENDPOINT_ID = "post_auth_signin"
+SIGNUP_ENDPOINT_ID = "post_auth_signup"
+
+
+@dataclass(frozen=True)
+class EndpointDefinition:
+    endpoint_id: str
+    method: str
+    path: str
+    expected_status: int
+    query_params: tuple[tuple[str, str], ...] = ()
+    body: dict[str, Any] | None = None
+
+    @property
+    def display_name(self) -> str:
+        return f"{self.method} {self.path}"
+
+
+EXPECTED_STATUS_OVERRIDES = {
+    ("POST", "/auth/signup"): 201,
+    ("POST", "/bugs"): 201,
+}
+
+QUERY_PARAM_SAMPLES = {
+    ("GET", "/bugs"): (("page", "1"), ("per_page", "20")),
+    ("GET", "/bugs/search"): (("q", "sql injection"), ("limit", "10")),
+    ("GET", "/auth/verify-email"): (("token", "sample-verification-token"),),
+}
+
+BODY_SAMPLES = {
+    ("POST", "/auth/signin"): {
+        "username": "{{username}}",
+        "password": "{{password}}",
+    },
+    ("POST", "/auth/signup"): {
+        "username": "{{signup_username}}",
+        "email": "{{signup_email}}",
+        "password": "{{signup_password}}",
+    },
+    ("POST", "/bugs"): {
+        "url": "https://example.com/vulnerability",
+        "description": "Bug report created from generated Postman collection endpoint.",
+        "status": "open",
+    },
+}
+
+
+def build_endpoint_id(method: str, path: str) -> str:
+    normalized_path = re.sub(r"[^a-z0-9]+", "_", path.lower()).strip("_")
+    return f"{method.lower()}_{normalized_path or 'root'}"
+
+
+def substitute_path_params(path: str) -> str:
+    return re.sub(r"\{[^}]+\}", "1", path)
+
+
+def discover_routes(main_file: Path = MAIN_FILE) -> list[EndpointDefinition]:
+    tree = ast.parse(main_file.read_text(encoding="utf-8"), filename=str(main_file))
+    routes: list[EndpointDefinition] = []
+
+    def iter_nodes_in_source_order(node: ast.AST) -> Iterable[ast.AST]:
+        for child in ast.iter_child_nodes(node):
+            yield child
+            yield from iter_nodes_in_source_order(child)
+
+    for statement in tree.body:
+        for node in iter_nodes_in_source_order(statement):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "add_route":
+                continue
+            if not isinstance(node.func.value, ast.Name) or node.func.value.id != "router":
+                continue
+            if len(node.args) < 3:
+                continue
+
+            method_node, path_node = node.args[:2]
+            if not isinstance(method_node, ast.Constant) or not isinstance(method_node.value, str):
+                continue
+            if not isinstance(path_node, ast.Constant) or not isinstance(path_node.value, str):
+                continue
+
+            method = method_node.value.upper()
+            path = path_node.value
+            if path == "/":
+                continue
+
+            routes.append(
+                EndpointDefinition(
+                    endpoint_id=build_endpoint_id(method, path),
+                    method=method,
+                    path=path,
+                    expected_status=EXPECTED_STATUS_OVERRIDES.get((method, path), 200),
+                    query_params=QUERY_PARAM_SAMPLES.get((method, path), ()),
+                    body=BODY_SAMPLES.get((method, path)),
+                )
+            )
+
+    return routes
+
+
+def reorder_endpoints(endpoints: list[EndpointDefinition]) -> list[EndpointDefinition]:
+    endpoint_map = {endpoint.endpoint_id: endpoint for endpoint in endpoints}
+    if LOGIN_ENDPOINT_ID not in endpoint_map:
+        return endpoints
+
+    ordered: list[EndpointDefinition] = [endpoint_map[LOGIN_ENDPOINT_ID]]
+    ordered.extend(
+        endpoint for endpoint in endpoints if endpoint.endpoint_id != LOGIN_ENDPOINT_ID
+    )
+    return ordered
+
+
+def build_postman_tests(endpoint: EndpointDefinition, response_time_ms: int) -> str:
+    lines = [
+        f'pm.test("Status code is {endpoint.expected_status}", function () {{',
+        f"    pm.response.to.have.status({endpoint.expected_status});",
+        "});",
+        "",
+        f'pm.test("Response time is below {response_time_ms}ms", function () {{',
+        f"    pm.expect(pm.response.responseTime).to.be.below({response_time_ms});",
+        "});",
+        "",
+        "let responseJson = null;",
+        'pm.test("Response body is valid JSON", function () {',
+        "    pm.expect(function () {",
+        "        responseJson = pm.response.json();",
+        "    }).to.not.throw();",
+        "    pm.expect(responseJson).to.not.equal(null);",
+        '    pm.expect(typeof responseJson).to.eql("object");',
+        "});",
+    ]
+
+    if endpoint.endpoint_id == LOGIN_ENDPOINT_ID:
+        lines.extend(
+            [
+                "",
+                'pm.test("Authentication token is present", function () {',
+                '    pm.expect(responseJson).to.have.property("token");',
+                '    pm.expect(responseJson.token).to.be.a("string").and.not.empty;',
+                '    pm.environment.set("token", responseJson.token);',
+                "});",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def build_prerequest_script(endpoint: EndpointDefinition) -> str | None:
+    if endpoint.endpoint_id != SIGNUP_ENDPOINT_ID:
+        return None
+
+    return "\n".join(
+        [
+            'const baseUsername = pm.environment.get("username");',
+            'const basePassword = pm.environment.get("password");',
+            "",
+            'pm.test("Signup source credentials are configured", function () {',
+            '    pm.expect(baseUsername).to.be.a("string").and.not.empty;',
+            '    pm.expect(basePassword).to.be.a("string").and.not.empty;',
+            "});",
+            "",
+            "const signupRunId = Date.now().toString();",
+            'pm.collectionVariables.set("signup_username", `${baseUsername}_signup_${signupRunId}`);',
+            'pm.collectionVariables.set("signup_password", `${basePassword}_signup`);',
+            'pm.collectionVariables.set("signup_email", `${baseUsername}_signup_${signupRunId}@example.com`);',
+        ]
+    )
+
+
+def build_url(endpoint: EndpointDefinition) -> str:
+    path = substitute_path_params(endpoint.path)
+    raw_url = f"{{{{base_url}}}}{path}"
+    if endpoint.query_params:
+        raw_url = f"{raw_url}?{urlencode(endpoint.query_params)}"
+    return raw_url
+
+
+def build_request_item(endpoint: EndpointDefinition, response_time_ms: int) -> dict[str, Any]:
+    headers = [{"key": "Accept", "value": "application/json"}]
+    if endpoint.endpoint_id != LOGIN_ENDPOINT_ID:
+        headers.append({"key": "Authorization", "value": "Token {{token}}"})
+    if endpoint.body is not None:
+        headers.append({"key": "Content-Type", "value": "application/json"})
+
+    request: dict[str, Any] = {
+        "method": endpoint.method,
+        "header": headers,
+        "url": build_url(endpoint),
+        "description": f"Generated from {endpoint.method} {endpoint.path}",
+    }
+
+    if endpoint.body is not None:
+        request["body"] = {
+            "mode": "raw",
+            "raw": json.dumps(endpoint.body, indent=2),
+            "options": {"raw": {"language": "json"}},
+        }
+
+    events = []
+    prerequest_script = build_prerequest_script(endpoint)
+    if prerequest_script is not None:
+        events.append(
+            {
+                "listen": "prerequest",
+                "script": {
+                    "type": "text/javascript",
+                    "exec": prerequest_script.splitlines(),
+                },
+            }
+        )
+
+    events.append(
+        {
+            "listen": "test",
+            "script": {
+                "type": "text/javascript",
+                "exec": build_postman_tests(endpoint, response_time_ms).splitlines(),
+            },
+        }
+    )
+
+    return {
+        "name": endpoint.display_name,
+        "event": events,
+        "request": request,
+        "response": [],
+    }
+
+
+def build_collection(response_time_ms: int = DEFAULT_RESPONSE_TIME_MS) -> dict[str, Any]:
+    endpoints = reorder_endpoints(discover_routes())
+
+    return {
+        "info": {
+            "name": "BLT API",
+            "description": "Generated Postman Collection v2.1 for the BLT API.",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        },
+        "item": [build_request_item(endpoint, response_time_ms) for endpoint in endpoints],
+    }
+
+
+async def handle_postman_collection(
+    request: Any,
+    env: Any,
+    path_params: Dict[str, str],
+    query_params: Dict[str, str],
+    path: str,
+) -> Any:
+    """Return a generated Postman collection JSON payload.
+
+    Query params:
+    - response_time_ms: optional positive integer used in generated Postman tests.
+    """
+    del request, env, path_params, path
+
+    response_time_ms = DEFAULT_RESPONSE_TIME_MS
+    raw_response_time_ms = query_params.get("response_time_ms")
+
+    if raw_response_time_ms is not None:
+        try:
+            response_time_ms = int(raw_response_time_ms)
+            if response_time_ms <= 0:
+                raise ValueError
+        except ValueError:
+            return error_response(
+                message="Invalid response_time_ms. Expected a positive integer.",
+                status=400,
+            )
+
+    collection = build_collection(response_time_ms=response_time_ms)
+
+    return json_response(
+        collection,
+        headers={
+            "Content-Disposition": 'attachment; filename="blt_api_postman_collection.json"'
+        },
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,8 @@ from handlers import (
     handle_homepage,
     handle_signup,
     handle_signin,
-    handle_verify_email
+    handle_verify_email,
+    handle_postman_collection,
 )
 from utils import json_response, error_response, cors_headers
 from libs.db import get_db_safe 
@@ -65,6 +66,10 @@ router.add_route("GET", "/users/{id}/following", handle_users)
 router.add_route("POST", "/auth/signup", handle_signup)
 router.add_route("POST", "/auth/signin", handle_signin)
 router.add_route("GET", "/auth/verify-email", handle_verify_email)  # Email verification route
+
+# Tooling API
+router.add_route("GET", "/postman-collection", handle_postman_collection)
+router.add_route("GET", "/postman-collection.json", handle_postman_collection)
 
 # Domains API
 router.add_route("GET", "/domains", handle_domains)


### PR DESCRIPTION
### Overview

This PR introduces a Python utility that automatically generates a **Postman Collection (v2.1)** for the BLT API by analyzing the project's routing configuration.

The script parses the API routes defined in `src/main.py` and produces a ready-to-import Postman collection that includes requests, sample payloads, and automated tests.

### CLI Usage

Generate the collection:

```bash
python generate_postman_collection.py
```

List discovered endpoints:

```bash
python generate_postman_collection.py --list-endpoints
```

Customize request execution order:

```bash
python generate_postman_collection.py --order post_auth_signin get_bugs
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to generate a Postman Collection from discovered API routes, including auth token handling, per-endpoint sample data, built-in request tests, configurable execution order, response-time assertions, and options to list or output collections.

* **Documentation**
  * Expanded README with Postman generation workflow, import steps, environment variable setup, execution-order guidance, and notes for endpoints needing manual parameter input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->