### PR TITLE
feat: add JOIN support to QuerySet in orm.py

### DIFF
--- a/src/libs/orm.py
+++ b/src/libs/orm.py
@@ -336,24 +336,24 @@ class QuerySet:
     # Full query builder
     # ------------------------------------------------------------------
 
-    def _build_join_clause(self) -> str:
-        """Return the JOIN clause string for all active joins."""
-        return " ".join(
-            f"{join_type} JOIN {join_table} ON {on_clause}"
-            for join_type, join_table, on_clause in self._joins
-        )
+    def _build_from_with_joins_sql(self) -> str:
+        """Return the FROM clause with all JOIN clauses appended.
+
+        Used by both ``_build_select_sql()`` and ``count()`` to avoid
+        duplicating FROM+JOIN assembly logic.
+        """
+        table = self._model.table_name
+        sql = f"FROM {table}"
+        for join_type, join_table, on_clause in self._joins:
+            sql += f" {join_type} JOIN {join_table} ON {on_clause}"
+        return sql
 
     def _build_select_sql(self) -> Tuple[str, List[Any]]:
         """Build the full ``SELECT`` SQL and its parameter list."""
-        table = self._model.table_name
         select = ", ".join(self._select_fields) if self._select_fields else "*"
 
         where, params = self._build_where_clause()
-        sql = f"SELECT {select} FROM {table}"
-
-        join_clause = self._build_join_clause()
-        if join_clause:
-            sql += f" {join_clause}"
+        sql = f"SELECT {select} {self._build_from_with_joins_sql()}"
 
         if where:
             sql += f" {where}"
@@ -405,12 +405,8 @@ class QuerySet:
         form ``table1.col = table2.col``. Compound ON conditions are not
         currently supported.
         """
-        table = self._model.table_name
         where, params = self._build_where_clause()
-        sql = f"SELECT COUNT(*) AS total FROM {table}"
-        join_clause = self._build_join_clause()
-        if join_clause:
-            sql += f" {join_clause}"
+        sql = f"SELECT COUNT(*) AS total {self._build_from_with_joins_sql()}"
         if where:
             sql += f" {where}"
         result = await self._db.prepare(sql).bind(*params).first()

--- a/src/libs/orm.py
+++ b/src/libs/orm.py
@@ -236,6 +236,8 @@ class QuerySet:
             )
         _validate_identifier(table)
         # Validate each side of the ON clause (format: "a.b = c.d")
+        # Strip spaces for parsing, but validate the stripped parts
+        # and reconstruct a canonical form to prevent whitespace-folding bypasses
         on_stripped = on.replace(" ", "")
         if "=" not in on_stripped:
             raise ValueError(
@@ -244,9 +246,11 @@ class QuerySet:
         lhs, rhs = on_stripped.split("=", 1)
         _validate_identifier(lhs)
         _validate_identifier(rhs)
+        # Store canonical form (no spaces) to prevent whitespace-folding bypasses
+        canonical_on = f"{lhs} = {rhs}"
 
         qs = self._clone()
-        qs._joins.append((join_type, table, on))
+        qs._joins.append((join_type, table, canonical_on))
         return qs
 
     def paginate(self, page: int = 1, per_page: int = 20) -> "QuerySet":

--- a/src/libs/orm.py
+++ b/src/libs/orm.py
@@ -336,6 +336,13 @@ class QuerySet:
     # Full query builder
     # ------------------------------------------------------------------
 
+    def _build_join_clause(self) -> str:
+        """Return the JOIN clause string for all active joins."""
+        return " ".join(
+            f"{join_type} JOIN {join_table} ON {on_clause}"
+            for join_type, join_table, on_clause in self._joins
+        )
+
     def _build_select_sql(self) -> Tuple[str, List[Any]]:
         """Build the full ``SELECT`` SQL and its parameter list."""
         table = self._model.table_name
@@ -344,8 +351,9 @@ class QuerySet:
         where, params = self._build_where_clause()
         sql = f"SELECT {select} FROM {table}"
 
-        for join_type, join_table, on_clause in self._joins:
-            sql += f" {join_type} JOIN {join_table} ON {on_clause}"
+        join_clause = self._build_join_clause()
+        if join_clause:
+            sql += f" {join_clause}"
 
         if where:
             sql += f" {where}"
@@ -400,8 +408,9 @@ class QuerySet:
         table = self._model.table_name
         where, params = self._build_where_clause()
         sql = f"SELECT COUNT(*) AS total FROM {table}"
-        for join_type, join_table, on_clause in self._joins:
-            sql += f" {join_type} JOIN {join_table} ON {on_clause}"
+        join_clause = self._build_join_clause()
+        if join_clause:
+            sql += f" {join_clause}"
         if where:
             sql += f" {where}"
         result = await self._db.prepare(sql).bind(*params).first()

--- a/src/libs/orm.py
+++ b/src/libs/orm.py
@@ -386,10 +386,20 @@ class QuerySet:
         return await self.filter(**kwargs).first()
 
     async def count(self) -> int:
-        """Return the number of rows matching the current filters."""
+        """Return the number of rows matching the current filters.
+
+        JOIN clauses (if any) are included so that filters on joined
+        columns produce consistent results with ``all()`` and ``first()``.
+
+        Note: The ON clause only supports simple equality conditions of the
+        form ``table1.col = table2.col``. Compound ON conditions are not
+        currently supported.
+        """
         table = self._model.table_name
         where, params = self._build_where_clause()
         sql = f"SELECT COUNT(*) AS total FROM {table}"
+        for join_type, join_table, on_clause in self._joins:
+            sql += f" {join_type} JOIN {join_table} ON {on_clause}"
         if where:
             sql += f" {where}"
         result = await self._db.prepare(sql).bind(*params).first()

--- a/src/libs/orm.py
+++ b/src/libs/orm.py
@@ -132,6 +132,8 @@ class QuerySet:
         self._offset_val: int = 0
         self._order_by_fields: List[str] = []
         self._select_fields: List[str] = []
+        # Each entry: (join_type, table, on_clause)
+        self._joins: List[Tuple[str, str, str]] = []
 
     # ------------------------------------------------------------------
     # Cloning
@@ -145,6 +147,7 @@ class QuerySet:
         qs._offset_val = self._offset_val
         qs._order_by_fields = list(self._order_by_fields)
         qs._select_fields = list(self._select_fields)
+        qs._joins = list(self._joins)
         return qs
 
     # ------------------------------------------------------------------
@@ -199,6 +202,49 @@ class QuerySet:
         """Select only the specified columns (validated identifiers)."""
         qs = self._clone()
         qs._select_fields = [_validate_identifier(f) for f in fields]
+        return qs
+
+    def join(
+        self,
+        table: str,
+        on: str,
+        join_type: str = "INNER",
+    ) -> "QuerySet":
+        """Add a JOIN clause to the query.
+
+        :param table: The table name to join (validated).
+        :param on: The ON condition, e.g. ``"bugs.domain_id = domains.id"``.
+                   Both sides are validated as safe identifiers.
+        :param join_type: ``"INNER"``, ``"LEFT"``, ``"RIGHT"`` or ``"FULL"``.
+                          Defaults to ``"INNER"``.
+
+        Example::
+
+            Bug.objects(db)\
+                .join("domains", on="bugs.domain_id = domains.id", join_type="LEFT")\
+                .filter(status="open")\
+                .values("bugs.id", "bugs.title", "domains.name")\
+                .all()
+        """
+        join_type = join_type.upper()
+        if join_type not in {"INNER", "LEFT", "RIGHT", "FULL"}:
+            raise ValueError(
+                f"Unsupported join_type {join_type!r}. "
+                "Use INNER, LEFT, RIGHT or FULL."
+            )
+        _validate_identifier(table)
+        # Validate each side of the ON clause (format: "a.b = c.d")
+        on_stripped = on.replace(" ", "")
+        if "=" not in on_stripped:
+            raise ValueError(
+                f"Invalid ON clause {on!r}. Expected format: 'table1.col = table2.col'."
+            )
+        lhs, rhs = on_stripped.split("=", 1)
+        _validate_identifier(lhs)
+        _validate_identifier(rhs)
+
+        qs = self._clone()
+        qs._joins.append((join_type, table, on))
         return qs
 
     def paginate(self, page: int = 1, per_page: int = 20) -> "QuerySet":
@@ -295,6 +341,10 @@ class QuerySet:
 
         where, params = self._build_where_clause()
         sql = f"SELECT {select} FROM {table}"
+
+        for join_type, join_table, on_clause in self._joins:
+            sql += f" {join_type} JOIN {join_table} ON {on_clause}"
+
         if where:
             sql += f" {where}"
 

--- a/src/libs/orm.py
+++ b/src/libs/orm.py
@@ -215,6 +215,8 @@ class QuerySet:
         :param table: The table name to join (validated).
         :param on: The ON condition, e.g. ``"bugs.domain_id = domains.id"``.
                    Both sides are validated as safe identifiers.
+                   Only a single equality condition is supported;
+                   compound conditions (e.g. ``AND``) are not allowed.
         :param join_type: ``"INNER"``, ``"LEFT"``, ``"RIGHT"`` or ``"FULL"``.
                           Defaults to ``"INNER"``.
 

--- a/src/libs/orm.py
+++ b/src/libs/orm.py
@@ -411,7 +411,16 @@ class QuerySet:
         return (await self.count()) > 0
 
     async def update(self, **kwargs: Any) -> None:
-        """Update all matching rows with the supplied field=value pairs."""
+        """Update all matching rows with the supplied field=value pairs.
+
+        Raises ``ValueError`` if the QuerySet has active JOINs, as UPDATE
+        with JOIN is not supported by this ORM.
+        """
+        if self._joins:
+            raise ValueError(
+                "update() is not supported on QuerySets with active JOINs. "
+                "Remove .join() calls before calling .update()."
+            )
         if not kwargs:
             return
         table = self._model.table_name
@@ -429,7 +438,16 @@ class QuerySet:
         await self._db.prepare(sql).bind(*set_params, *where_params).run()
 
     async def delete(self) -> None:
-        """Delete all matching rows."""
+        """Delete all matching rows.
+
+        Raises ``ValueError`` if the QuerySet has active JOINs, as DELETE
+        with JOIN is not supported by this ORM.
+        """
+        if self._joins:
+            raise ValueError(
+                "delete() is not supported on QuerySets with active JOINs. "
+                "Remove .join() calls before calling .delete()."
+            )
         table = self._model.table_name
         where, params = self._build_where_clause()
         sql = f"DELETE FROM {table}"

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -534,6 +534,24 @@ class TestJoin:
                 on="bugs.domain_id = domains.id; DROP TABLE bugs--"
             )
 
+    def test_join_on_clause_canonical_form_stored(self):
+        """Whitespace-folding bypass prevention — canonical ON clause is stored."""
+        qs = self.qs.join(
+            "domains",
+            on="bugs.domain_id = domains.id"
+        )
+        _, join_table, on_clause = qs._joins[0]
+        assert on_clause == "bugs.domain_id = domains.id"
+        assert "  " not in on_clause
+
+    def test_join_on_clause_whitespace_folding_bypass_rejected(self):
+        """Extra whitespace cannot be used to smuggle unsafe expressions."""
+        with pytest.raises(ValueError):
+            self.qs.join(
+                "domains",
+                on="bugs.domain_id = domains.id OR 1"
+            )
+
     def test_join_on_clause_without_equals_raises(self):
         with pytest.raises(ValueError):
             self.qs.join("domains", on="bugs.domain_id")

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -540,7 +540,7 @@ class TestJoin:
             "domains",
             on="bugs.domain_id = domains.id"
         )
-        _, join_table, on_clause = qs._joins[0]
+        _, _, on_clause = qs._joins[0]
         assert on_clause == "bugs.domain_id = domains.id"
         assert "  " not in on_clause
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -527,6 +527,13 @@ class TestJoin:
                 on="bugs.domain_id; DROP TABLE bugs-- = domains.id"
             )
 
+    def test_join_unsafe_on_rhs_raises(self):
+        with pytest.raises(ValueError):
+            self.qs.join(
+                "domains",
+                on="bugs.domain_id = domains.id; DROP TABLE bugs--"
+            )
+
     def test_join_on_clause_without_equals_raises(self):
         with pytest.raises(ValueError):
             self.qs.join("domains", on="bugs.domain_id")

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -576,14 +576,14 @@ class TestUpdateDeleteJoinGuards:
 
     @pytest.mark.asyncio
     async def test_update_with_join_raises(self):
-        with pytest.raises(ValueError, match="update\(\) is not supported"):
+        with pytest.raises(ValueError, match=r"update() is not supported"):
             await self.qs.join(
                 "domains", on="bugs.domain_id = domains.id"
             ).update(status="open")
 
     @pytest.mark.asyncio
     async def test_delete_with_join_raises(self):
-        with pytest.raises(ValueError, match="delete\(\) is not supported"):
+        with pytest.raises(ValueError, match=r"delete() is not supported"):
             await self.qs.join(
                 "domains", on="bugs.domain_id = domains.id"
             ).delete()

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -601,14 +601,14 @@ class TestUpdateDeleteJoinGuards:
 
     @pytest.mark.asyncio
     async def test_update_with_join_raises(self):
-        with pytest.raises(ValueError, match=r"update() is not supported"):
+        with pytest.raises(ValueError, match=r"update\(\) is not supported"):
             await self.qs.join(
                 "domains", on="bugs.domain_id = domains.id"
             ).update(status="open")
 
     @pytest.mark.asyncio
     async def test_delete_with_join_raises(self):
-        with pytest.raises(ValueError, match=r"delete() is not supported"):
+        with pytest.raises(ValueError, match=r"delete\(\) is not supported"):
             await self.qs.join(
                 "domains", on="bugs.domain_id = domains.id"
             ).delete()

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -483,3 +483,117 @@ class TestModelUpdateById:
         await _TestModel.update_by_id(db, 42, is_active=False)
         assert "UPDATE test_table" in db._last_sql
         assert "WHERE id = ?" in db._last_sql
+
+
+# ---------------------------------------------------------------------------
+# QuerySet.join — SQL generation and validation
+# ---------------------------------------------------------------------------
+
+
+class TestJoin:
+    def setup_method(self):
+        self.db = MockDB()
+        self.qs = QuerySet(_TestModel, self.db)
+
+    def test_join_generates_correct_sql(self):
+        sql, _ = self.qs.join(
+            "domains", on="bugs.domain_id = domains.id", join_type="LEFT"
+        )._build_select_sql()
+        assert "LEFT JOIN domains ON bugs.domain_id = domains.id" in sql
+
+    def test_inner_join_default(self):
+        sql, _ = self.qs.join(
+            "domains", on="bugs.domain_id = domains.id"
+        )._build_select_sql()
+        assert "INNER JOIN domains ON bugs.domain_id = domains.id" in sql
+
+    def test_join_invalid_type_raises(self):
+        with pytest.raises(ValueError):
+            self.qs.join(
+                "domains", on="bugs.domain_id = domains.id", join_type="CROSS"
+            )
+
+    def test_join_unsafe_table_name_raises(self):
+        with pytest.raises(ValueError):
+            self.qs.join(
+                "domains; DROP TABLE bugs--",
+                on="bugs.domain_id = domains.id"
+            )
+
+    def test_join_unsafe_on_lhs_raises(self):
+        with pytest.raises(ValueError):
+            self.qs.join(
+                "domains",
+                on="bugs.domain_id; DROP TABLE bugs-- = domains.id"
+            )
+
+    def test_join_on_clause_without_equals_raises(self):
+        with pytest.raises(ValueError):
+            self.qs.join("domains", on="bugs.domain_id")
+
+    def test_join_does_not_mutate_original(self):
+        original = self.qs
+        joined = original.join("domains", on="bugs.domain_id = domains.id")
+        assert original._joins == []
+        assert len(joined._joins) == 1
+
+    def test_multiple_joins_chained(self):
+        sql, _ = self.qs            .join("domains", on="bugs.domain_id = domains.id", join_type="LEFT")            .join("tags", on="bugs.tag_id = tags.id", join_type="INNER")            ._build_select_sql()
+        assert "LEFT JOIN domains ON bugs.domain_id = domains.id" in sql
+        assert "INNER JOIN tags ON bugs.tag_id = tags.id" in sql
+
+    def test_join_placed_before_where(self):
+        sql, _ = self.qs            .join("domains", on="bugs.domain_id = domains.id", join_type="LEFT")            .filter(id=1)            ._build_select_sql()
+        join_pos = sql.index("LEFT JOIN")
+        where_pos = sql.index("WHERE")
+        assert join_pos < where_pos
+
+    @pytest.mark.asyncio
+    async def test_count_with_join_includes_join_clause(self):
+        self.db._first_return = {"total": 5}
+        await self.qs.join(
+            "domains", on="bugs.domain_id = domains.id", join_type="LEFT"
+        ).count()
+        assert "LEFT JOIN domains ON bugs.domain_id = domains.id" in self.db._last_sql
+        assert "COUNT(*)" in self.db._last_sql
+
+    @pytest.mark.asyncio
+    async def test_count_without_join_excludes_join_clause(self):
+        self.db._first_return = {"total": 3}
+        await self.qs.filter(id=1).count()
+        assert "JOIN" not in self.db._last_sql
+
+
+# ---------------------------------------------------------------------------
+# QuerySet.update and delete — JOIN guards
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateDeleteJoinGuards:
+    def setup_method(self):
+        self.db = MockDB()
+        self.qs = QuerySet(_TestModel, self.db)
+
+    @pytest.mark.asyncio
+    async def test_update_with_join_raises(self):
+        with pytest.raises(ValueError, match="update\(\) is not supported"):
+            await self.qs.join(
+                "domains", on="bugs.domain_id = domains.id"
+            ).update(status="open")
+
+    @pytest.mark.asyncio
+    async def test_delete_with_join_raises(self):
+        with pytest.raises(ValueError, match="delete\(\) is not supported"):
+            await self.qs.join(
+                "domains", on="bugs.domain_id = domains.id"
+            ).delete()
+
+    @pytest.mark.asyncio
+    async def test_update_without_join_works(self):
+        await self.qs.filter(id=1).update(status="open")
+        assert "UPDATE test_table" in self.db._last_sql
+
+    @pytest.mark.asyncio
+    async def test_delete_without_join_works(self):
+        await self.qs.filter(id=1).delete()
+        assert "DELETE FROM test_table" in self.db._last_sql


### PR DESCRIPTION
## Summary
Closes #61

Required to unblock PR #44 which cannot be merged until 
all raw SQL JOIN queries in bugs.py are replaced with ORM calls.

## Changes to `src/libs/orm.py`

### New `.join()` chainable method
Added a `.join(table, on, join_type)` method to `QuerySet`:

```python
Bug.objects(db)\
    .join("domains", on="bugs.domain_id = domains.id", join_type="LEFT")\
    .filter(status="open")\
    .values("bugs.id", "bugs.title", "domains.name")\
    .all()

Security

table name validated via _validate_identifier()
Both sides of the ON clause validated as safe identifiers
join_type restricted to INNER, LEFT, RIGHT, FULL
No user-controlled values embedded in SQL

Updated _build_select_sql()

JOIN clauses are inserted between FROM {table} and WHERE:
SELECT ... FROM bugs LEFT JOIN domains ON bugs.domain_id = domains.id WHERE ...

Supported join types

LEFT — for bugs → domains (domain may be null)
INNER — for bug_tags → tags
RIGHT, FULL — available for future use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable SQL JOIN support (INNER/LEFT) preserved across query copies and included in SELECT/COUNT.

* **Bug Fixes**
  * Validated/canonicalized ON clauses and identifiers; ensured JOINs apply before WHERE so counts match results.
  * Prevented destructive UPDATE/DELETE when JOINs are present.

* **Tests**
  * Added comprehensive tests for join SQL, validation, chaining, counting, and update/delete guards.

* **Documentation**
  * Updated docstrings to describe JOIN behavior and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->