### PR TITLE
fix: Add headers parameter to error_response for proper 405 Allow header support

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -89,7 +89,8 @@ def json_response(
 def error_response(
     message: str,
     status: int = 400,
-    details: Optional[Dict[str, Any]] = None
+    details: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None
 ) -> Response:
     """
     Create an error JSON response.
@@ -98,6 +99,7 @@ def error_response(
         message: Error message
         status: HTTP status code
         details: Additional error details
+        headers: Additional HTTP headers to include (e.g., {"Allow": "POST"} for 405 responses)
     
     Returns:
         Response object with error information
@@ -111,7 +113,7 @@ def error_response(
     if details:
         error_data["details"] = details
     
-    return json_response(error_data, status=status)
+    return json_response(error_data, status=status, headers=headers)
 
 
 def success_response(


### PR DESCRIPTION
`error_response()` in `utils.py` had no `headers` parameter, but `auth.py` passes `headers={"Allow": "POST"}` in three places. This caused a `TypeError` at runtime on any non-allowed HTTP method to auth endpoints.
Added an optional `headers` parameter that passes through to `json_response()`, which already supports extra headers. Defaults to `None` so existing callers are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error response handling to support custom HTTP headers, providing greater flexibility in error communication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->