### PR TITLE
Add /routes endpoint for programmatic API discoverability

### DIFF
--- a/src/handlers/__init__.py
+++ b/src/handlers/__init__.py
@@ -18,6 +18,7 @@ from .repos import handle_repos
 from .health import handle_health
 from .homepage import handle_homepage
 from .auth import handle_signup, handle_signin, handle_verify_email
+from .routes import handle_routes
 
 __all__ = [
     "handle_bugs",
@@ -35,4 +36,5 @@ __all__ = [
     "handle_signup",
     "handle_signin",
     "handle_verify_email",
+    "handle_routes",
 ]

--- a/src/handlers/__init__.py
+++ b/src/handlers/__init__.py
@@ -18,7 +18,7 @@ from .repos import handle_repos
 from .health import handle_health
 from .homepage import handle_homepage
 from .auth import handle_signup, handle_signin, handle_verify_email
-from .routes import handle_routes
+from .routes import make_routes_handler
 
 __all__ = [
     "handle_bugs",
@@ -36,5 +36,5 @@ __all__ = [
     "handle_signup",
     "handle_signin",
     "handle_verify_email",
-    "handle_routes",
+    "make_routes_handler",
 ]

--- a/src/handlers/routes.py
+++ b/src/handlers/routes.py
@@ -4,29 +4,43 @@ Routes handler for the BLT API.
 Exposes registered API routes for programmatic discoverability.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Callable
 from workers import Response
+from router import Router
 
 
-async def handle_routes(
-    request: Any,
-    env: Any,
-    path_params: Dict[str, str],
-    query_params: Dict[str, str],
-    path: str
-) -> Any:
+def make_routes_handler(router: Router) -> Callable:
     """
-    Handle route discovery requests.
-
-    Endpoints:
-        GET /routes - List all registered API routes
+    Create a routes handler with access to the router instance.
+    
+    This factory pattern avoids circular imports by accepting the router
+    as a parameter rather than importing it from main.
+    
+    Args:
+        router: The Router instance to query for registered routes
+    
+    Returns:
+        An async handler function for the /routes endpoint
     """
-    from main import router
+    async def handle_routes(
+        request: Any,
+        env: Any,
+        path_params: Dict[str, str],
+        query_params: Dict[str, str],
+        path: str
+    ) -> Any:
+        """
+        Handle route discovery requests.
 
-    routes = router.get_route_list()
+        Endpoints:
+            GET /routes - List all registered API routes
+        """
+        routes = router.get_route_list()
 
-    return Response.json({
-        "success": True,
-        "data": routes,
-        "count": len(routes)
-    })
+        return Response.json({
+            "success": True,
+            "data": routes,
+            "count": len(routes)
+        })
+    
+    return handle_routes

--- a/src/handlers/routes.py
+++ b/src/handlers/routes.py
@@ -1,0 +1,32 @@
+"""
+Routes handler for the BLT API.
+
+Exposes registered API routes for programmatic discoverability.
+"""
+
+from typing import Any, Dict
+from workers import Response
+
+
+async def handle_routes(
+    request: Any,
+    env: Any,
+    path_params: Dict[str, str],
+    query_params: Dict[str, str],
+    path: str
+) -> Any:
+    """
+    Handle route discovery requests.
+
+    Endpoints:
+        GET /routes - List all registered API routes
+    """
+    from main import router
+
+    routes = router.get_route_list()
+
+    return Response.json({
+        "success": True,
+        "data": routes,
+        "count": len(routes)
+    })

--- a/src/main.py
+++ b/src/main.py
@@ -32,7 +32,7 @@ from handlers import (
     handle_signup,
     handle_signin,
     handle_verify_email,
-    handle_routes
+    make_routes_handler
 )
 from utils import json_response, error_response, cors_headers
 from libs.db import get_db_safe 
@@ -109,8 +109,8 @@ router.add_route("GET", "/contributors/{id}", handle_contributors)
 router.add_route("GET", "/repos", handle_repos)
 router.add_route("GET", "/repos/{id}", handle_repos)
 
-# API Discoverability
-router.add_route("GET", "/routes", handle_routes)
+# API Discoverability - uses factory pattern to avoid circular imports
+router.add_route("GET", "/routes", make_routes_handler(router))
 
 class Default(WorkerEntrypoint):
     async def on_fetch(self, request):

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,8 @@ from handlers import (
     handle_homepage,
     handle_signup,
     handle_signin,
-    handle_verify_email
+    handle_verify_email,
+    handle_routes
 )
 from utils import json_response, error_response, cors_headers
 from libs.db import get_db_safe 
@@ -107,6 +108,9 @@ router.add_route("GET", "/contributors/{id}", handle_contributors)
 # Repositories API
 router.add_route("GET", "/repos", handle_repos)
 router.add_route("GET", "/repos/{id}", handle_repos)
+
+# API Discoverability
+router.add_route("GET", "/routes", handle_routes)
 
 class Default(WorkerEntrypoint):
     async def on_fetch(self, request):

--- a/src/router.py
+++ b/src/router.py
@@ -117,13 +117,12 @@ class Router:
         """Return metadata for all registered routes.
 
         Returns:
-            List of dicts with method, path, and handler name for each route.
+            List of dicts with method and path for each route.
         """
         return [
             {
                 "method": route.method,
                 "path": route.pattern,
-                "handler": route.handler.__name__,
             }
             for route in self.routes
         ]

--- a/src/router.py
+++ b/src/router.py
@@ -113,6 +113,21 @@ class Router:
             return handler
         return decorator
     
+    def get_route_list(self) -> List[Dict[str, str]]:
+        """Return metadata for all registered routes.
+
+        Returns:
+            List of dicts with method, path, and handler name for each route.
+        """
+        return [
+            {
+                "method": route.method,
+                "path": route.pattern,
+                "handler": route.handler.__name__,
+            }
+            for route in self.routes
+        ]
+
     def _parse_url(self, url: str) -> str:
         """Extract the path from a full URL."""
         # Handle full URLs

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -280,5 +280,70 @@ class TestRouteRegistrationOrder:
         assert matched_route.match(method, path) == {}
 
 
+class TestRouterGetRouteList:
+    """Tests for Router.get_route_list() method."""
+    
+    def test_get_route_list_empty(self):
+        """Test get_route_list returns empty list for router with no routes."""
+        router = Router()
+        assert router.get_route_list() == []
+    
+    def test_get_route_list_single_route(self):
+        """Test get_route_list with a single registered route."""
+        router = Router()
+        router.add_route("GET", "/users", lambda: None)
+        
+        result = router.get_route_list()
+        assert len(result) == 1
+        assert result[0] == {"method": "GET", "path": "/users"}
+    
+    def test_get_route_list_multiple_routes(self):
+        """Test get_route_list with multiple routes."""
+        router = Router()
+        router.add_route("GET", "/users", lambda: None)
+        router.add_route("POST", "/bugs", lambda: None)
+        router.add_route("GET", "/domains/{id}", lambda: None)
+        
+        result = router.get_route_list()
+        assert len(result) == 3
+        assert result == [
+            {"method": "GET", "path": "/users"},
+            {"method": "POST", "path": "/bugs"},
+            {"method": "GET", "path": "/domains/{id}"},
+        ]
+    
+    def test_get_route_list_no_handler_exposed(self):
+        """Test that handler names are not included in route list."""
+        router = Router()
+        
+        def my_handler():
+            pass
+        
+        router.add_route("GET", "/test", my_handler)
+        
+        result = router.get_route_list()
+        assert len(result) == 1
+        assert "handler" not in result[0]
+        assert result[0].keys() == {"method", "path"}
+    
+    def test_get_route_list_preserves_method_case(self):
+        """Test that HTTP methods are stored in uppercase."""
+        router = Router()
+        router.add_route("get", "/test", lambda: None)
+        router.add_route("post", "/test", lambda: None)
+        
+        result = router.get_route_list()
+        assert result[0]["method"] == "GET"
+        assert result[1]["method"] == "POST"
+    
+    def test_get_route_list_includes_path_params(self):
+        """Test that path parameters are preserved in route list."""
+        router = Router()
+        router.add_route("GET", "/users/{id}/posts/{post_id}", lambda: None)
+        
+        result = router.get_route_list()
+        assert result[0]["path"] == "/users/{id}/posts/{post_id}"
+
+
 
 


### PR DESCRIPTION
Adds a `GET /routes` endpoint that returns all registered API routes as structured JSON. The data is built dynamically from the router's internal registry so it never drifts out of sync.

New `get_route_list()` method on `Router` returns each route's method, path pattern, and handler name. This enables any client to programmatically discover available API operations without hardcoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GET /routes endpoint (also available under v2) that returns JSON with a success flag, a list of all registered API routes (HTTP method and path), and a total route count for easier discovery.
* **Tests**
  * Added tests verifying route-listing behavior: empty/single/multiple routes, method casing, and preservation of path parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->