### PR TITLE
fix(router): return 405 with Allow header for method mismatch

### DIFF
--- a/src/router.py
+++ b/src/router.py
@@ -6,9 +6,13 @@ path parameters and different HTTP methods.
 """
 
 import re
+import logging
 from urllib.parse import parse_qs, urlparse
 from typing import Callable, Dict, List, Optional, Tuple, Any
 from utils import error_response, json_response
+
+
+logger = logging.getLogger(__name__)
 
 
 class Route:
@@ -178,9 +182,13 @@ class Router:
                     query_params=query_params,
                     path=path
                 )
-            except Exception as e:
+            except Exception:
+                logger.exception(
+                    "Unhandled route handler exception",
+                    extra={"method": method, "path": path}
+                )
                 return error_response(
-                    message=f"Handler error: {e!s}",
+                    message="Internal Server Error",
                     status=500
                 )
 

--- a/src/router.py
+++ b/src/router.py
@@ -160,24 +160,29 @@ class Router:
         
         # Try to match against registered routes
         for route in self.routes:
-            if route.regex.match(path):
-                allowed_methods.add(route.method)
+            match = route.regex.match(path)
+            if not match:
+                continue
 
-            path_params = route.match(method, path)
-            if path_params is not None:
-                try:
-                    return await route.handler(
-                        request=request,
-                        env=env,
-                        path_params=path_params,
-                        query_params=query_params,
-                        path=path
-                    )
-                except Exception as e:
-                    return error_response(
-                        message=f"Handler error: {e!s}",
-                        status=500
-                    )
+            allowed_methods.add(route.method)
+
+            if route.method != method:
+                continue
+
+            path_params = match.groupdict()
+            try:
+                return await route.handler(
+                    request=request,
+                    env=env,
+                    path_params=path_params,
+                    query_params=query_params,
+                    path=path
+                )
+            except Exception as e:
+                return error_response(
+                    message=f"Handler error: {e!s}",
+                    status=500
+                )
 
         # Path exists but method does not
         if allowed_methods:

--- a/src/router.py
+++ b/src/router.py
@@ -156,9 +156,13 @@ class Router:
         method = str(request.method).upper()
         path = self._parse_url(url)
         query_params = self._parse_query_params(url)
+        allowed_methods = set()
         
         # Try to match against registered routes
         for route in self.routes:
+            if route.regex.match(path):
+                allowed_methods.add(route.method)
+
             path_params = route.match(method, path)
             if path_params is not None:
                 try:
@@ -171,9 +175,18 @@ class Router:
                     )
                 except Exception as e:
                     return error_response(
-                        message=f"Handler error: {str(e)}",
+                        message=f"Handler error: {e!s}",
                         status=500
                     )
+
+        # Path exists but method does not
+        if allowed_methods:
+            allow_header = ", ".join(sorted(allowed_methods))
+            return error_response(
+                message="Method Not Allowed",
+                status=405,
+                headers={"Allow": allow_header}
+            )
         
         # No route matched
         return error_response(

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from router import Route, Router
+from router import Route, Router  # pyright: ignore[reportMissingImports]
 
 
 class TestRoute:
@@ -236,6 +236,27 @@ class TestRouterHandleMethodBehavior:
         assert getattr(response, "status", None) == 404
         body = json.loads(response.body)
         assert body["status"] == 404
+
+    @pytest.mark.asyncio
+    async def test_handle_returns_405_with_aggregated_sorted_allow_header(self):
+        router = Router()
+
+        async def generic_handler(request, env, path_params, query_params, path):
+            return {"ok": True}
+
+        router.add_route("GET", "/bugs", generic_handler)
+        router.add_route("HEAD", "/bugs", generic_handler)
+        router.add_route("POST", "/bugs", generic_handler)
+
+        request = _MockRequest("PUT", "https://example.com/bugs")
+        response = await router.handle(request, env={})
+
+        assert getattr(response, "status", None) == 405
+        assert response.headers.get("Allow") == "GET, HEAD, POST"
+
+        body = json.loads(response.body)
+        assert body["status"] == 405
+        assert body["message"] == "Method Not Allowed"
 
 
 class TestRouteRegistrationOrder:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2,8 +2,14 @@
 Tests for the Router module.
 """
 
+import json
 import pytest
-from src.router import Route, Router
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from router import Route, Router
 
 
 class TestRoute:
@@ -183,6 +189,53 @@ class TestRouterDecorators:
         
         assert len(router.routes) == 1
         assert router.routes[0].method == "DELETE"
+
+
+class _MockRequest:
+    """Simple mock request for Router.handle tests."""
+
+    def __init__(self, method: str, url: str):
+        self.method = method
+        self.url = url
+
+
+class TestRouterHandleMethodBehavior:
+    """Tests for Router.handle status behavior around method/path matching."""
+
+    @pytest.mark.asyncio
+    async def test_handle_returns_405_with_allow_header_when_path_exists(self):
+        router = Router()
+
+        async def get_handler(request, env, path_params, query_params, path):
+            return {"ok": True}
+
+        router.add_route("GET", "/bugs", get_handler)
+
+        request = _MockRequest("POST", "https://example.com/bugs")
+        response = await router.handle(request, env={})
+
+        assert getattr(response, "status", None) == 405
+        assert response.headers.get("Allow") == "GET"
+
+        body = json.loads(response.body)
+        assert body["status"] == 405
+        assert body["message"] == "Method Not Allowed"
+
+    @pytest.mark.asyncio
+    async def test_handle_returns_404_when_path_not_found(self):
+        router = Router()
+
+        async def get_handler(request, env, path_params, query_params, path):
+            return {"ok": True}
+
+        router.add_route("GET", "/bugs", get_handler)
+
+        request = _MockRequest("GET", "https://example.com/unknown")
+        response = await router.handle(request, env={})
+
+        assert getattr(response, "status", None) == 404
+        body = json.loads(response.body)
+        assert body["status"] == 404
 
 
 class TestRouteRegistrationOrder:


### PR DESCRIPTION
## Summary
Fixes router method handling so existing paths return 405 (with `Allow`) instead of 404, while unknown paths still return 404.

## Changes
- Added method-aware path matching.
- Added sorted `Allow` header for 405 responses.
- Reused single regex match per route.
- Replaced raw 500 exception text with generic message and server-side logging.
- Added tests for 405 + `Allow` (single and multi-method) and 404 fallback.

## Testing
- Ran router tests.
- Verified 405 + `Allow` behavior.
- Verified unknown paths return 404.