### PR TITLE
 Add follow/unfollow user endpoints

### DIFF
--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -680,6 +680,8 @@ async def follow_user(db: Any, request: Any, env: Any, target_user_id: str) -> A
         except Exception as e:
             if "UNIQUE constraint failed" in str(e):
                 return error_response("Already following this user", status=409)
+            if "FOREIGN KEY constraint failed" in str(e):
+                return error_response("User not found", status=404)
             raise
 
         return Response.json({"success": True, "message": "User followed"}, status=201)

--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -239,6 +239,9 @@ async def handle_users(
     if method not in {"GET", "POST", "DELETE"}:
         return error_response("Method Not Allowed", status=405, headers={"Allow": "GET, POST, DELETE"})
     
+    if method == "DELETE" and "id" not in path_params:
+        return error_response("Method Not Allowed", status=405, headers={"Allow": "GET, POST"})
+    
     try: 
         db = await get_db_safe(env)  
     except Exception as e:
@@ -672,8 +675,10 @@ async def follow_user(db: Any, request: Any, env: Any, target_user_id: str) -> A
             await db.prepare(
                 "INSERT INTO user_follows (follower_id, following_id) VALUES (?, ?)"
             ).bind(follower_id, following_id).run()
-        except Exception:
-            return error_response("Already following this user", status=409)
+        except Exception as e:
+            if "UNIQUE constraint failed" in str(e):
+                return error_response("Already following this user", status=409)
+            raise
 
         return Response.json({"success": True, "message": "User followed"}, status=201)
     except Exception as e:

--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -673,10 +673,14 @@ async def follow_user(db: Any, request: Any, env: Any, target_user_id: str) -> A
         if not target:
             return error_response("User not found", status=404)
 
+        existing = await UserFollow.objects(db).filter(
+            follower_id=follower_id, following_id=following_id
+        ).first()
+        if existing:
+            return error_response("Already following this user", status=409)
+
         try:
-            await db.prepare(
-                "INSERT INTO user_follows (follower_id, following_id) VALUES (?, ?)"
-            ).bind(follower_id, following_id).run()
+            await UserFollow.create(db, follower_id=follower_id, following_id=following_id)
         except Exception as e:
             if "UNIQUE constraint failed" in str(e):
                 return error_response("Already following this user", status=409)
@@ -714,12 +718,15 @@ async def unfollow_user(db: Any, request: Any, env: Any, target_user_id: str) ->
         if follower_id == following_id:
             return error_response("Cannot unfollow yourself", status=400)
 
-        result = await db.prepare(
-            "DELETE FROM user_follows WHERE follower_id = ? AND following_id = ? RETURNING id"
-        ).bind(follower_id, following_id).first()
-
-        if not result:
+        existing = await UserFollow.objects(db).filter(
+            follower_id=follower_id, following_id=following_id
+        ).first()
+        if not existing:
             return error_response("Not following this user", status=404)
+
+        await UserFollow.objects(db).filter(
+            follower_id=follower_id, following_id=following_id
+        ).delete()
 
         return Response.json({"success": True, "message": "User unfollowed"})
     except Exception as e:

--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -644,7 +644,10 @@ async def follow_user(db: Any, request: Any, env: Any, target_user_id: str) -> A
     """Follow a user. Requires JWT authentication."""
     logger = logging.getLogger(__name__)
     try:
-        token = _get_header(request, "Authorization").replace("Bearer ", "")
+        auth_header = _get_header(request, "Authorization")
+        if not auth_header:
+            return error_response("Authentication required", status=401)
+        token = auth_header.replace("Bearer ", "")
         if not token:
             return error_response("Authentication required", status=401)
 
@@ -682,7 +685,10 @@ async def unfollow_user(db: Any, request: Any, env: Any, target_user_id: str) ->
     """Unfollow a user. Requires JWT authentication."""
     logger = logging.getLogger(__name__)
     try:
-        token = _get_header(request, "Authorization").replace("Bearer ", "")
+        auth_header = _get_header(request, "Authorization")
+        if not auth_header:
+            return error_response("Authentication required", status=401)
+        token = auth_header.replace("Bearer ", "")
         if not token:
             return error_response("Authentication required", status=401)
 

--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -282,6 +282,8 @@ async def handle_users(
                 return await get_user_followers(db, env, user_id, query_params)
             elif path.endswith("/following"):
                 return await get_user_following(db, env, user_id, query_params)
+            elif path.endswith("/follow"):
+                return error_response("Method Not Allowed", status=405, headers={"Allow": "POST, DELETE"})
             else:
                 # Get basic user info
                 return await get_user(db, env, user_id)

--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -709,6 +709,9 @@ async def unfollow_user(db: Any, request: Any, env: Any, target_user_id: str) ->
             return error_response("Invalid or expired token", status=401)
         following_id = int(target_user_id)
 
+        if follower_id == following_id:
+            return error_response("Cannot unfollow yourself", status=400)
+
         result = await db.prepare(
             "DELETE FROM user_follows WHERE follower_id = ? AND following_id = ? RETURNING id"
         ).bind(follower_id, following_id).first()

--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -645,9 +645,9 @@ async def follow_user(db: Any, request: Any, env: Any, target_user_id: str) -> A
     logger = logging.getLogger(__name__)
     try:
         auth_header = _get_header(request, "Authorization")
-        if not auth_header:
+        if not auth_header or not auth_header.startswith("Bearer "):
             return error_response("Authentication required", status=401)
-        token = auth_header.replace("Bearer ", "")
+        token = auth_header[7:]
         if not token:
             return error_response("Authentication required", status=401)
 
@@ -655,7 +655,10 @@ async def follow_user(db: Any, request: Any, env: Any, target_user_id: str) -> A
         if not payload or not payload.get("user_id"):
             return error_response("Invalid or expired token", status=401)
 
-        follower_id = int(payload["user_id"])
+        try:
+            follower_id = int(payload["user_id"])
+        except (ValueError, TypeError):
+            return error_response("Invalid or expired token", status=401)
         following_id = int(target_user_id)
 
         if follower_id == following_id:
@@ -665,20 +668,17 @@ async def follow_user(db: Any, request: Any, env: Any, target_user_id: str) -> A
         if not target:
             return error_response("User not found", status=404)
 
-        existing = await UserFollow.objects(db).filter(
-            follower_id=follower_id, following_id=following_id
-        ).first()
-        if existing:
+        try:
+            await db.prepare(
+                "INSERT INTO user_follows (follower_id, following_id) VALUES (?, ?)"
+            ).bind(follower_id, following_id).run()
+        except Exception:
             return error_response("Already following this user", status=409)
-
-        await db.prepare(
-            "INSERT INTO user_follows (follower_id, following_id) VALUES (?, ?)"
-        ).bind(follower_id, following_id).run()
 
         return Response.json({"success": True, "message": "User followed"}, status=201)
     except Exception as e:
         logger.error(f"Error following user: {str(e)}")
-        return error_response(f"Error following user: {str(e)}", status=500)
+        return error_response("Internal server error", status=500)
 
 
 async def unfollow_user(db: Any, request: Any, env: Any, target_user_id: str) -> Any:
@@ -686,9 +686,9 @@ async def unfollow_user(db: Any, request: Any, env: Any, target_user_id: str) ->
     logger = logging.getLogger(__name__)
     try:
         auth_header = _get_header(request, "Authorization")
-        if not auth_header:
+        if not auth_header or not auth_header.startswith("Bearer "):
             return error_response("Authentication required", status=401)
-        token = auth_header.replace("Bearer ", "")
+        token = auth_header[7:]
         if not token:
             return error_response("Authentication required", status=401)
 
@@ -696,7 +696,10 @@ async def unfollow_user(db: Any, request: Any, env: Any, target_user_id: str) ->
         if not payload or not payload.get("user_id"):
             return error_response("Invalid or expired token", status=401)
 
-        follower_id = int(payload["user_id"])
+        try:
+            follower_id = int(payload["user_id"])
+        except (ValueError, TypeError):
+            return error_response("Invalid or expired token", status=401)
         following_id = int(target_user_id)
 
         existing = await UserFollow.objects(db).filter(
@@ -712,4 +715,4 @@ async def unfollow_user(db: Any, request: Any, env: Any, target_user_id: str) ->
         return Response.json({"success": True, "message": "User unfollowed"})
     except Exception as e:
         logger.error(f"Error unfollowing user: {str(e)}")
-        return error_response(f"Error unfollowing user: {str(e)}", status=500)
+        return error_response("Internal server error", status=500)

--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -707,15 +707,12 @@ async def unfollow_user(db: Any, request: Any, env: Any, target_user_id: str) ->
             return error_response("Invalid or expired token", status=401)
         following_id = int(target_user_id)
 
-        existing = await UserFollow.objects(db).filter(
-            follower_id=follower_id, following_id=following_id
-        ).first()
-        if not existing:
-            return error_response("Not following this user", status=404)
+        result = await db.prepare(
+            "DELETE FROM user_follows WHERE follower_id = ? AND following_id = ? RETURNING id"
+        ).bind(follower_id, following_id).first()
 
-        await db.prepare(
-            "DELETE FROM user_follows WHERE follower_id = ? AND following_id = ?"
-        ).bind(follower_id, following_id).run()
+        if not result:
+            return error_response("Not following this user", status=404)
 
         return Response.json({"success": True, "message": "User unfollowed"})
     except Exception as e:

--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -11,6 +11,7 @@ from utils import error_response, parse_pagination_params, convert_d1_results, p
 from libs.db import get_db_safe
 from libs.constant import __HASHING_ITERATIONS
 from libs.data_protection import encrypt_sensitive, decrypt_sensitive, blind_index
+from libs.jwt_utils import decode_jwt
 from workers import Response
 from models import User, Bug, Domain, UserFollow
 import logging
@@ -229,12 +230,14 @@ async def handle_users(
         GET /users/{id}/domains - Get domains submitted by user
         GET /users/{id}/followers - Get user's followers
         GET /users/{id}/following - Get users this user follows
+        POST /users/{id}/follow - Follow a user (auth required)
+        DELETE /users/{id}/follow - Unfollow a user (auth required)
     """
     method = str(request.method).upper()
     logger = logging.getLogger(__name__)
 
-    if method not in {"GET", "POST"}:
-        return error_response("Method Not Allowed", status=405, headers={"Allow": "GET, POST"})
+    if method not in {"GET", "POST", "DELETE"}:
+        return error_response("Method Not Allowed", status=405, headers={"Allow": "GET, POST, DELETE"})
     
     try: 
         db = await get_db_safe(env)  
@@ -243,7 +246,15 @@ async def handle_users(
         return error_response("Service temporarily unavailable", status=503)
     
     try: 
-        if method == "POST" and "id" in path_params:
+        if method in ("POST", "DELETE") and "id" in path_params:
+            user_id = path_params["id"]
+            if not user_id.isdigit():
+                return error_response("Invalid user ID", status=400)
+            if path.endswith("/follow"):
+                if method == "POST":
+                    return await follow_user(db, request, env, user_id)
+                else:
+                    return await unfollow_user(db, request, env, user_id)
             return error_response("Method Not Allowed", status=405, headers={"Allow": "GET"})
 
         if method == "POST":
@@ -627,3 +638,72 @@ async def get_user_following(db: Any, env: Any, user_id: str, query_params: Dict
     except Exception as e:
         logger.error(f"Error fetching user following: {str(e)}")
         return error_response(f"Error fetching user following: {str(e)}", status=500)
+
+
+async def follow_user(db: Any, request: Any, env: Any, target_user_id: str) -> Any:
+    """Follow a user. Requires JWT authentication."""
+    logger = logging.getLogger(__name__)
+    try:
+        token = _get_header(request, "Authorization").replace("Bearer ", "")
+        if not token:
+            return error_response("Authentication required", status=401)
+
+        payload = decode_jwt(token, env.JWT_SECRET)
+        if not payload or not payload.get("user_id"):
+            return error_response("Invalid or expired token", status=401)
+
+        follower_id = int(payload["user_id"])
+        following_id = int(target_user_id)
+
+        if follower_id == following_id:
+            return error_response("Cannot follow yourself", status=400)
+
+        target = await User.objects(db).get(id=following_id)
+        if not target:
+            return error_response("User not found", status=404)
+
+        existing = await UserFollow.objects(db).filter(
+            follower_id=follower_id, following_id=following_id
+        ).first()
+        if existing:
+            return error_response("Already following this user", status=409)
+
+        await db.prepare(
+            "INSERT INTO user_follows (follower_id, following_id) VALUES (?, ?)"
+        ).bind(follower_id, following_id).run()
+
+        return Response.json({"success": True, "message": "User followed"}, status=201)
+    except Exception as e:
+        logger.error(f"Error following user: {str(e)}")
+        return error_response(f"Error following user: {str(e)}", status=500)
+
+
+async def unfollow_user(db: Any, request: Any, env: Any, target_user_id: str) -> Any:
+    """Unfollow a user. Requires JWT authentication."""
+    logger = logging.getLogger(__name__)
+    try:
+        token = _get_header(request, "Authorization").replace("Bearer ", "")
+        if not token:
+            return error_response("Authentication required", status=401)
+
+        payload = decode_jwt(token, env.JWT_SECRET)
+        if not payload or not payload.get("user_id"):
+            return error_response("Invalid or expired token", status=401)
+
+        follower_id = int(payload["user_id"])
+        following_id = int(target_user_id)
+
+        existing = await UserFollow.objects(db).filter(
+            follower_id=follower_id, following_id=following_id
+        ).first()
+        if not existing:
+            return error_response("Not following this user", status=404)
+
+        await db.prepare(
+            "DELETE FROM user_follows WHERE follower_id = ? AND following_id = ?"
+        ).bind(follower_id, following_id).run()
+
+        return Response.json({"success": True, "message": "User unfollowed"})
+    except Exception as e:
+        logger.error(f"Error unfollowing user: {str(e)}")
+        return error_response(f"Error unfollowing user: {str(e)}", status=500)

--- a/src/main.py
+++ b/src/main.py
@@ -61,6 +61,8 @@ router.add_route("GET", "/users/{id}/bugs", handle_users)
 router.add_route("GET", "/users/{id}/domains", handle_users)
 router.add_route("GET", "/users/{id}/followers", handle_users)
 router.add_route("GET", "/users/{id}/following", handle_users)
+router.add_route("POST", "/users/{id}/follow", handle_users)
+router.add_route("DELETE", "/users/{id}/follow", handle_users)
 
 # Auth API
 router.add_route("POST", "/auth/signup", handle_signup)
@@ -136,6 +138,8 @@ _add_v2_route("GET", "/users/{id}/bugs", handle_users)
 _add_v2_route("GET", "/users/{id}/domains", handle_users)
 _add_v2_route("GET", "/users/{id}/followers", handle_users)
 _add_v2_route("GET", "/users/{id}/following", handle_users)
+_add_v2_route("POST", "/users/{id}/follow", handle_users)
+_add_v2_route("DELETE", "/users/{id}/follow", handle_users)
 
 _add_v2_route("POST", "/auth/signup", handle_signup)
 _add_v2_route("POST", "/auth/signin", handle_signin)


### PR DESCRIPTION
## Summary

Adds write endpoints to complete the user follow/unfollow feature. The read side
(followers list, following list, profile counts) already exists — but there was
no way to actually create or remove a follow relationship.

## What existed before this PR

- `user_follows` D1 table with `UNIQUE(follower_id, following_id)` constraint
  and `CHECK(follower_id != following_id)` (migration 0003)
- `UserFollow` ORM model
- `GET /users/{id}/followers` — paginated followers list
- `GET /users/{id}/following` — paginated following list
- `GET /users/{id}/profile` — includes follower/following counts

## What this PR adds

| Endpoint | Description |
|----------|-------------|
| `POST /users/{id}/follow` | Authenticated user follows target user |
| `DELETE /users/{id}/follow` | Authenticated user unfollows target user |

Both endpoints require a valid JWT token in the `Authorization: Bearer <token>` header.

## Validation & error handling

- **401** — Missing or invalid/expired JWT token
- **400** — Self-follow attempt or invalid user ID
- **404** — Target user not found (follow) / not following (unfollow)
- **409** — Already following this user
- **201** — Successfully followed
- **200** — Successfully unfollowed

## Files changed

- `src/handlers/users.py` — Added `follow_user()` and `unfollow_user()` functions,
  updated routing to handle POST/DELETE on `/users/{id}/follow`
- `src/main.py` — Registered new routes under both `/` and `/v2` prefixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added follow/unfollow endpoints (POST /users/{id}/follow, DELETE /users/{id}/follow) in base and /v2 APIs; require JWT auth. Successful follow returns 201 Created; unfollow returns a success response.

* **Bug Fixes / Validation**
  * Added validation and error responses: 400 for invalid IDs or self-follow, 401 for missing/invalid tokens, 404 when target user or relationship is absent, 409 for duplicate follows, and 405 for unsupported methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->