### PR TITLE
feat: cache database initialization status to improve performance

### DIFF
--- a/src/libs/db.py
+++ b/src/libs/db.py
@@ -60,6 +60,11 @@ async def check_db_initialized(db):
         raise Exception(f"Failed to check database initialization: {str(e)}")
 
 
+# Global cache for database initialization status.
+# In Cloudflare Workers, global variables persist between requests on the same isolate.
+_DB_INITIALIZED_CACHE: bool = False
+
+
 async def get_db_safe(env):
     """Get database and verify it's properly initialized.
     
@@ -72,14 +77,19 @@ async def get_db_safe(env):
     Raises:
         Exception: If database is not configured or not initialized
     """
+    global _DB_INITIALIZED_CACHE
+    
     db = get_db(env)
     
-    is_initialized, missing_tables = await check_db_initialized(db)
-    
-    if not is_initialized:
-        raise Exception(
-            f"Database is not initialized. Missing tables: {', '.join(missing_tables)}. "
-            "Please run migrations first."
-        )
+    if not _DB_INITIALIZED_CACHE:
+        is_initialized, missing_tables = await check_db_initialized(db)
+        
+        if not is_initialized:
+            raise Exception(
+                f"Database is not initialized. Missing tables: {', '.join(missing_tables)}. "
+                "Please run migrations first."
+            )
+        
+        _DB_INITIALIZED_CACHE = True
     
     return db

--- a/src/libs/db.py
+++ b/src/libs/db.py
@@ -1,5 +1,6 @@
 import asyncio
 import weakref
+from typing import Optional
 
 # Global cache for database initialization status.
 # In Cloudflare Workers, global variables persist between requests on the same isolate.
@@ -17,6 +18,21 @@ def get_db_initialized_lock() -> asyncio.Lock:
         lock = asyncio.Lock()
         _DB_INITIALIZED_LOCKS[loop] = lock
     return lock
+
+
+def reset_db_cache(loop: "Optional[asyncio.AbstractEventLoop]" = None) -> None:
+    """Resets the database initialization cache state.
+    
+    If *loop* is provided, ONLY the lock for that specific loop is removed.
+    The global cache flag is always reset to False to force a re-check.
+    """
+    global _DB_INITIALIZED_CACHE
+    _DB_INITIALIZED_CACHE = False
+    
+    if loop is not None:
+        _DB_INITIALIZED_LOCKS.pop(loop, None)
+    else:
+        _DB_INITIALIZED_LOCKS.clear()
 
 
 def get_db(env):

--- a/src/libs/db.py
+++ b/src/libs/db.py
@@ -1,3 +1,11 @@
+import asyncio
+
+# Global cache for database initialization status.
+# In Cloudflare Workers, global variables persist between requests on the same isolate.
+_DB_INITIALIZED_CACHE: bool = False
+_DB_INITIALIZED_LOCK = asyncio.Lock()
+
+
 def get_db(env):
     """Helper to get DB binding from env, handling different env types.
     
@@ -58,14 +66,6 @@ async def check_db_initialized(db):
         
     except Exception as e:
         raise Exception(f"Failed to check database initialization: {str(e)}")
-
-
-import asyncio
-
-# Global cache for database initialization status.
-# In Cloudflare Workers, global variables persist between requests on the same isolate.
-_DB_INITIALIZED_CACHE: bool = False
-_DB_INITIALIZED_LOCK = asyncio.Lock()
 
 
 async def get_db_safe(env):

--- a/src/libs/db.py
+++ b/src/libs/db.py
@@ -1,9 +1,22 @@
 import asyncio
+import weakref
 
 # Global cache for database initialization status.
 # In Cloudflare Workers, global variables persist between requests on the same isolate.
 _DB_INITIALIZED_CACHE: bool = False
-_DB_INITIALIZED_LOCK = asyncio.Lock()
+_DB_INITIALIZED_LOCKS: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def get_db_initialized_lock() -> asyncio.Lock:
+    """Gets or creates an asyncio.Lock bound to the current running event loop."""
+    loop = asyncio.get_running_loop()
+    lock = _DB_INITIALIZED_LOCKS.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _DB_INITIALIZED_LOCKS[loop] = lock
+    return lock
 
 
 def get_db(env):
@@ -89,7 +102,7 @@ async def get_db_safe(env):
         return db
         
     # Slow path: need to check initialization, guarded by a lock to prevent race conditions
-    async with _DB_INITIALIZED_LOCK:
+    async with get_db_initialized_lock():
         # Double-check after acquiring lock
         if not _DB_INITIALIZED_CACHE:
             is_initialized, missing_tables = await check_db_initialized(db)

--- a/src/libs/db.py
+++ b/src/libs/db.py
@@ -60,9 +60,12 @@ async def check_db_initialized(db):
         raise Exception(f"Failed to check database initialization: {str(e)}")
 
 
+import asyncio
+
 # Global cache for database initialization status.
 # In Cloudflare Workers, global variables persist between requests on the same isolate.
 _DB_INITIALIZED_CACHE: bool = False
+_DB_INITIALIZED_LOCK = asyncio.Lock()
 
 
 async def get_db_safe(env):
@@ -81,15 +84,22 @@ async def get_db_safe(env):
     
     db = get_db(env)
     
-    if not _DB_INITIALIZED_CACHE:
-        is_initialized, missing_tables = await check_db_initialized(db)
+    # Fast path: already initialized
+    if _DB_INITIALIZED_CACHE:
+        return db
         
-        if not is_initialized:
-            raise Exception(
-                f"Database is not initialized. Missing tables: {', '.join(missing_tables)}. "
-                "Please run migrations first."
-            )
-        
-        _DB_INITIALIZED_CACHE = True
+    # Slow path: need to check initialization, guarded by a lock to prevent race conditions
+    async with _DB_INITIALIZED_LOCK:
+        # Double-check after acquiring lock
+        if not _DB_INITIALIZED_CACHE:
+            is_initialized, missing_tables = await check_db_initialized(db)
+            
+            if not is_initialized:
+                raise Exception(
+                    f"Database is not initialized. Missing tables: {', '.join(missing_tables)}. "
+                    "Please run migrations first."
+                )
+            
+            _DB_INITIALIZED_CACHE = True
     
     return db


### PR DESCRIPTION
**Description:**
This PR optimizes the database connection flow by caching the initialization status. Previously, the API would query `sqlite_master` on every request to ensure the schema was ready. This change ensures the check is only performed once per worker instance.
### Key Changes
- Introduced `_DB_INITIALIZED_CACHE` global boolean in [src/libs/db.py](cci:7://file:///d:/USER/BLT-API/src/libs/db.py:0:0-0:0).
- Modified [get_db_safe](cci:1://file:///d:/USER/BLT-API/src/libs/db.py:67:0-94:13) to skip [check_db_initialized](cci:1://file:///d:/USER/BLT-API/src/libs/db.py:19:0-59:77) if the cache flag is `True`.
### Performance Results (Benchmarked)
Using a simulated isolate handling 5 concurrent requests:
- **Before:** 5 initialization check queries.
- **After:** 1 initialization check query.
- **Result:** **80% reduction** in redundant database queries for this scenario.
### Verification
- Verified that [check_db_initialized](cci:1://file:///d:/USER/BLT-API/src/libs/db.py:19:0-59:77) is still called on the first request to ensure safety.
- Verified that subsequent requests bypass the check.
- Ran existing tests to ensure no regressions in database binding logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Database initialization is now cached so repeated verification is skipped, reducing latency on subsequent accesses and improving response times.

* **Reliability**
  * Concurrent startup is coordinated via an event-loop scoped mechanism to avoid redundant initialization and race conditions, improving stability during high-concurrency access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->