### PR TITLE
perf: cache database initialization check per worker isolate

### DIFF
--- a/src/libs/db.py
+++ b/src/libs/db.py
@@ -1,5 +1,8 @@
+import asyncio
+
 # Cache flag: once verified in a worker isolate, the schema is static for its lifetime.
 _db_initialized = False
+_db_init_lock = asyncio.Lock()
 
 
 def get_db(env):
@@ -85,14 +88,17 @@ async def get_db_safe(env):
     db = get_db(env)
 
     if not _db_initialized:
-        is_initialized, missing_tables = await check_db_initialized(db)
+        async with _db_init_lock:
+            # Double-check after acquiring lock to avoid redundant work
+            if not _db_initialized:
+                is_initialized, missing_tables = await check_db_initialized(db)
 
-        if not is_initialized:
-            raise Exception(
-                f"Database is not initialized. Missing tables: {', '.join(missing_tables)}. "
-                "Please run migrations first."
-            )
+                if not is_initialized:
+                    raise Exception(
+                        f"Database is not initialized. Missing tables: {', '.join(missing_tables)}. "
+                        "Please run migrations first."
+                    )
 
-        _db_initialized = True
+                _db_initialized = True
 
     return db

--- a/src/libs/db.py
+++ b/src/libs/db.py
@@ -1,3 +1,7 @@
+# Cache flag: once verified in a worker isolate, the schema is static for its lifetime.
+_db_initialized = False
+
+
 def get_db(env):
     """Helper to get DB binding from env, handling different env types.
     
@@ -63,6 +67,10 @@ async def check_db_initialized(db):
 async def get_db_safe(env):
     """Get database and verify it's properly initialized.
     
+    The initialization check is performed only once per worker isolate
+    lifetime and cached via a module-level flag. Subsequent calls skip
+    the redundant sqlite_master query.
+
     Args:
         env: Environment bindings
     
@@ -72,14 +80,19 @@ async def get_db_safe(env):
     Raises:
         Exception: If database is not configured or not initialized
     """
+    global _db_initialized
+
     db = get_db(env)
-    
-    is_initialized, missing_tables = await check_db_initialized(db)
-    
-    if not is_initialized:
-        raise Exception(
-            f"Database is not initialized. Missing tables: {', '.join(missing_tables)}. "
-            "Please run migrations first."
-        )
-    
+
+    if not _db_initialized:
+        is_initialized, missing_tables = await check_db_initialized(db)
+
+        if not is_initialized:
+            raise Exception(
+                f"Database is not initialized. Missing tables: {', '.join(missing_tables)}. "
+                "Please run migrations first."
+            )
+
+        _db_initialized = True
+
     return db


### PR DESCRIPTION
## Summary

Fixes #79

The `get_db_safe` function currently calls `check_db_initialized` (which queries `sqlite_master`) on **every incoming request**. Since Cloudflare Workers reuses isolates across requests and the database schema is static during a worker's lifetime, this query is redundant after the first successful verification.

## Changes

- Added a module-level `_db_initialized` cache flag in `src/libs/db.py`
- `get_db_safe` now skips the `sqlite_master` query on subsequent calls within the same isolate
- The check still runs on the first request and if the database is found to be uninitialized

## Performance Impact

- **Before:** 1 `sqlite_master` query per HTTP request
- **After:** 1 `sqlite_master` query per worker isolate lifetime
- For an isolate handling 1,000 requests, this eliminates ~999 redundant queries

## Testing

The change is backward-compatible — existing behavior is preserved, only the repetition is eliminated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database initialization performance by implementing a per-worker cache that skips redundant database validation checks after the first successful verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->