### PR TITLE
add PATCH /bugs/{id} endpoint for updating bugs

### DIFF
--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -42,7 +42,7 @@ async def handle_bugs(
         GET /bugs - List bugs with pagination and optional filters (status, domain, verified)
         GET /bugs/{id} - Get detailed bug info with screenshots and tags
         POST /bugs - Create a new bug report (requires url and description)
-        PATCH /bugs/{id} - Update a bug (auth required, owner or admin)
+        PATCH /bugs/{id} - Update a bug (auth required, owner only)
         GET /bugs/search - Search bugs by URL or description text (requires 'q' param)
     
     Query parameters for listing:

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -405,12 +405,10 @@ async def handle_bugs(
 async def update_bug(db: Any, request: Any, env: Any, bug_id_str: str, logger: Any) -> Any:
     """Update a bug. Requires JWT authentication. Only the bug owner can update."""
     try:
-        # Validate bug ID
         if not bug_id_str.isdigit():
             return error_response("Invalid bug ID", status=400)
         bug_id = int(bug_id_str)
 
-        # Authenticate
         auth_header = _get_header(request, "Authorization")
         if not auth_header or not auth_header.startswith("Bearer "):
             return error_response("Authentication required", status=401)
@@ -427,21 +425,17 @@ async def update_bug(db: Any, request: Any, env: Any, bug_id_str: str, logger: A
         except (ValueError, TypeError):
             return error_response("Invalid or expired token", status=401)
 
-        # Check bug exists
         bug = await Bug.objects(db).get(id=bug_id)
         if not bug:
             return error_response("Bug not found", status=404)
 
-        # Authorization: only the bug owner can update
         if bug.get("user") is not None and bug["user"] != user_id:
             return error_response("You can only update your own bugs", status=403)
 
-        # Parse request body
         body = await parse_json_body(request)
         if not body:
             return error_response("Request body is required", status=400)
 
-        # Build updates from allowed fields only
         updates = {}
         for field in body:
             if field not in _UPDATABLE_FIELDS:
@@ -449,7 +443,6 @@ async def update_bug(db: Any, request: Any, env: Any, bug_id_str: str, logger: A
 
             value = body[field]
 
-            # Validate status
             if field == "status":
                 if not isinstance(value, str) or value not in _VALID_STATUSES:
                     return error_response(
@@ -458,19 +451,16 @@ async def update_bug(db: Any, request: Any, env: Any, bug_id_str: str, logger: A
                     )
                 updates["status"] = value
 
-            # Validate boolean fields (SQLite stores as 0/1)
             elif field in ("verified", "is_hidden"):
                 if not isinstance(value, bool):
                     return error_response(f"{field} must be a boolean", status=400)
                 updates[field] = 1 if value else 0
 
-            # Validate integer fields
             elif field in ("score", "closed_by", "label"):
-                if not isinstance(value, int):
+                if isinstance(value, bool) or not isinstance(value, int):
                     return error_response(f"{field} must be an integer", status=400)
                 updates[field] = value
 
-            # Validate string fields
             elif field in ("markdown_description", "description", "github_url", "cve_id", "cve_score", "closed_date"):
                 if value is not None and not isinstance(value, str):
                     return error_response(f"{field} must be a string or null", status=400)
@@ -479,10 +469,8 @@ async def update_bug(db: Any, request: Any, env: Any, bug_id_str: str, logger: A
         if not updates:
             return error_response("No valid fields to update", status=400)
 
-        # Perform update
         await Bug.objects(db).filter(id=bug_id).update(**updates)
 
-        # Fetch and return the updated bug
         updated_bug = await Bug.objects(db).get(id=bug_id)
 
         return Response.json({

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -5,9 +5,28 @@ Bugs handler for the BLT API.
 from typing import Any, Dict
 from utils import error_response, parse_pagination_params, parse_json_body, convert_d1_results
 from libs.db import get_db_safe
+from libs.jwt_utils import decode_jwt
 from models import Bug
 from workers import Response
 import logging
+
+
+_UPDATABLE_FIELDS = {
+    "status", "verified", "score", "markdown_description",
+    "description", "github_url", "cve_id", "cve_score",
+    "is_hidden", "closed_by", "closed_date", "label",
+}
+
+_VALID_STATUSES = {"open", "closed", "in-progress", "reviewing"}
+
+
+def _get_header(request: Any, name: str) -> str:
+    """Safely read a request header in Workers and tests."""
+    headers = getattr(request, "headers", None)
+    if headers and hasattr(headers, "get"):
+        value = headers.get(name)
+        return str(value) if value is not None else ""
+    return ""
 
 async def handle_bugs(
     request: Any,
@@ -23,6 +42,7 @@ async def handle_bugs(
         GET /bugs - List bugs with pagination and optional filters (status, domain, verified)
         GET /bugs/{id} - Get detailed bug info with screenshots and tags
         POST /bugs - Create a new bug report (requires url and description)
+        PATCH /bugs/{id} - Update a bug (auth required, owner or admin)
         GET /bugs/search - Search bugs by URL or description text (requires 'q' param)
     
     Query parameters for listing:
@@ -91,6 +111,10 @@ async def handle_bugs(
             "data": response_data
         })
     
+    # Update bug (must be checked before GET /bugs/{id})
+    if method == "PATCH" and "id" in path_params:
+        return await update_bug(db, request, env, path_params["id"], logger)
+
     # Get specific bug
     if "id" in path_params:
         try:
@@ -293,7 +317,7 @@ async def handle_bugs(
         except Exception as e:
             logger.error(f"Error creating bug: {str(e)}")
             return error_response(f"Failed to create bug: {str(e)}", status=500)
-    
+
     # List bugs with pagination
     page, per_page = parse_pagination_params(query_params)
 
@@ -376,3 +400,96 @@ async def handle_bugs(
     except Exception as e:
         logger.error(f"Error fetching bugs: {str(e)}")
         return error_response(f"Failed to fetch bugs: {str(e)}", status=500)
+
+
+async def update_bug(db: Any, request: Any, env: Any, bug_id_str: str, logger: Any) -> Any:
+    """Update a bug. Requires JWT authentication. Only the bug owner can update."""
+    try:
+        # Validate bug ID
+        if not bug_id_str.isdigit():
+            return error_response("Invalid bug ID", status=400)
+        bug_id = int(bug_id_str)
+
+        # Authenticate
+        auth_header = _get_header(request, "Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return error_response("Authentication required", status=401)
+        token = auth_header[7:]
+        if not token:
+            return error_response("Authentication required", status=401)
+
+        payload = decode_jwt(token, env.JWT_SECRET)
+        if not payload or not payload.get("user_id"):
+            return error_response("Invalid or expired token", status=401)
+
+        try:
+            user_id = int(payload["user_id"])
+        except (ValueError, TypeError):
+            return error_response("Invalid or expired token", status=401)
+
+        # Check bug exists
+        bug = await Bug.objects(db).get(id=bug_id)
+        if not bug:
+            return error_response("Bug not found", status=404)
+
+        # Authorization: only the bug owner can update
+        if bug.get("user") is not None and bug["user"] != user_id:
+            return error_response("You can only update your own bugs", status=403)
+
+        # Parse request body
+        body = await parse_json_body(request)
+        if not body:
+            return error_response("Request body is required", status=400)
+
+        # Build updates from allowed fields only
+        updates = {}
+        for field in body:
+            if field not in _UPDATABLE_FIELDS:
+                continue
+
+            value = body[field]
+
+            # Validate status
+            if field == "status":
+                if not isinstance(value, str) or value not in _VALID_STATUSES:
+                    return error_response(
+                        f"Invalid status. Must be one of: {', '.join(sorted(_VALID_STATUSES))}",
+                        status=400,
+                    )
+                updates["status"] = value
+
+            # Validate boolean fields (SQLite stores as 0/1)
+            elif field in ("verified", "is_hidden"):
+                if not isinstance(value, bool):
+                    return error_response(f"{field} must be a boolean", status=400)
+                updates[field] = 1 if value else 0
+
+            # Validate integer fields
+            elif field in ("score", "closed_by", "label"):
+                if not isinstance(value, int):
+                    return error_response(f"{field} must be an integer", status=400)
+                updates[field] = value
+
+            # Validate string fields
+            elif field in ("markdown_description", "description", "github_url", "cve_id", "cve_score", "closed_date"):
+                if value is not None and not isinstance(value, str):
+                    return error_response(f"{field} must be a string or null", status=400)
+                updates[field] = value
+
+        if not updates:
+            return error_response("No valid fields to update", status=400)
+
+        # Perform update
+        await Bug.objects(db).filter(id=bug_id).update(**updates)
+
+        # Fetch and return the updated bug
+        updated_bug = await Bug.objects(db).get(id=bug_id)
+
+        return Response.json({
+            "success": True,
+            "message": "Bug updated successfully",
+            "data": updated_bug,
+        })
+    except Exception as e:
+        logger.error(f"Error updating bug: {str(e)}")
+        return error_response("Internal server error", status=500)

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -429,7 +429,7 @@ async def update_bug(db: Any, request: Any, env: Any, bug_id_str: str, logger: A
         if not bug:
             return error_response("Bug not found", status=404)
 
-        if bug.get("user") is not None and bug["user"] != user_id:
+        if bug.get("user") is None or bug["user"] != user_id:
             return error_response("You can only update your own bugs", status=403)
 
         body = await parse_json_body(request)

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -410,9 +410,9 @@ async def update_bug(db: Any, request: Any, env: Any, bug_id_str: str, logger: A
         bug_id = int(bug_id_str)
 
         auth_header = _get_header(request, "Authorization")
-        if not auth_header or not auth_header.startswith("Bearer "):
+        if not auth_header or not auth_header[:7].lower() == "bearer ":
             return error_response("Authentication required", status=401)
-        token = auth_header[7:]
+        token = auth_header[7:].strip()
         if not token:
             return error_response("Authentication required", status=401)
 

--- a/src/main.py
+++ b/src/main.py
@@ -50,6 +50,7 @@ router.add_route("GET", "/health", handle_health)
 router.add_route("GET", "/bugs/search", handle_bugs)
 router.add_route("GET", "/bugs", handle_bugs)
 router.add_route("POST", "/bugs", handle_bugs)
+router.add_route("PATCH", "/bugs/{id}", handle_bugs)
 router.add_route("GET", "/bugs/{id}", handle_bugs)
 
 # Users API
@@ -126,6 +127,7 @@ _add_v2_route("GET", "/health", handle_health)
 _add_v2_route("GET", "/bugs/search", handle_bugs)
 _add_v2_route("GET", "/bugs", handle_bugs)
 _add_v2_route("POST", "/bugs", handle_bugs)
+_add_v2_route("PATCH", "/bugs/{id}", handle_bugs)
 _add_v2_route("GET", "/bugs/{id}", handle_bugs)
 
 _add_v2_route("GET", "/users", handle_users)

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -26,7 +26,7 @@ sys.modules["workers"] = _mock_workers
 
 # Removed sys.modules.js mock for same reason as test_auth
 
-from handlers.bugs import handle_bugs  # noqa: E402
+from handlers.bugs import handle_bugs, update_bug  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -97,9 +97,10 @@ class MockDB:
 
 
 class MockRequest:
-    def __init__(self, method="GET", body=None):
+    def __init__(self, method="GET", body=None, headers=None):
         self.method = method
         self._body = body
+        self.headers = headers or {}
 
     async def text(self):
         if self._body is None:
@@ -110,7 +111,7 @@ class MockRequest:
 
 
 class MockEnv:
-    pass
+    JWT_SECRET = "test-secret-key"
 
 
 def _make_mock_bug_class(count=0):
@@ -328,4 +329,256 @@ class TestDatabaseConnectionErrors:
     async def test_db_error_on_create_returns_500(self):
         with patch("handlers.bugs.get_db_safe", AsyncMock(side_effect=Exception("DB down"))):
             resp = await handle_bugs(MockRequest(method="POST", body={"url": "https://x.com", "description": "d"}), MockEnv(), {}, {}, "/bugs")
+        assert resp.status == 500
+
+
+def _make_auth_header(user_id=1):
+    """Create a valid Bearer token for testing."""
+    from libs.jwt_utils import encode_jwt
+    token = encode_jwt({"user_id": user_id}, MockEnv.JWT_SECRET)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_mock_bug_qs(get_return=None, first_return=None, update_side_effect=None):
+    """Build a mock Bug ORM queryset for PATCH tests."""
+    mock_qs = MagicMock()
+    mock_qs.filter.return_value = mock_qs
+    mock_qs.get = AsyncMock(return_value=get_return)
+    mock_qs.first = AsyncMock(return_value=first_return)
+    mock_qs.update = AsyncMock(side_effect=update_side_effect)
+    mock_bug = MagicMock()
+    mock_bug.objects.return_value = mock_qs
+    return mock_bug, mock_qs
+
+
+class TestUpdateBug:
+    """Tests for PATCH /bugs/{id}."""
+
+    # -- Auth tests --
+
+    async def test_no_auth_header_returns_401(self):
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed"}),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 401
+
+    async def test_invalid_token_returns_401(self):
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed"}, headers={"Authorization": "Bearer bad-token"}),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 401
+
+    async def test_missing_bearer_prefix_returns_401(self):
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed"}, headers={"Authorization": "Token abc"}),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 401
+
+    # -- Validation tests --
+
+    async def test_non_integer_id_returns_400(self):
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed"}, headers=_make_auth_header()),
+                MockEnv(), {"id": "abc"}, {}, "/bugs/abc",
+            )
+        assert resp.status == 400
+
+    async def test_empty_body_returns_400(self):
+        bug = {"id": 1, "user": 1, "status": "open"}
+        mock_bug, _ = _make_mock_bug_qs(get_return=bug)
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body=None, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 400
+
+    async def test_no_valid_fields_returns_400(self):
+        bug = {"id": 1, "user": 1, "status": "open"}
+        mock_bug, _ = _make_mock_bug_qs(get_return=bug)
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"id": 999, "created": "2020-01-01"}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 400
+
+    async def test_invalid_status_returns_400(self):
+        bug = {"id": 1, "user": 1, "status": "open"}
+        mock_bug, _ = _make_mock_bug_qs(get_return=bug)
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "banana"}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 400
+
+    async def test_verified_not_bool_returns_400(self):
+        bug = {"id": 1, "user": 1, "status": "open"}
+        mock_bug, _ = _make_mock_bug_qs(get_return=bug)
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"verified": "yes"}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 400
+
+    async def test_score_not_int_returns_400(self):
+        bug = {"id": 1, "user": 1, "status": "open"}
+        mock_bug, _ = _make_mock_bug_qs(get_return=bug)
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"score": "high"}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 400
+
+    # -- Not found / authorization tests --
+
+    async def test_bug_not_found_returns_404(self):
+        mock_bug, _ = _make_mock_bug_qs(get_return=None)
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed"}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "999"}, {}, "/bugs/999",
+            )
+        assert resp.status == 404
+
+    async def test_non_owner_returns_403(self):
+        bug = {"id": 1, "user": 42, "status": "open"}  # owned by user 42
+        mock_bug, _ = _make_mock_bug_qs(get_return=bug)
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed"}, headers=_make_auth_header(1)),  # user 1 trying
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 403
+
+    # -- Success tests --
+
+    async def test_update_status_success(self):
+        bug = {"id": 1, "user": 1, "status": "open"}
+        updated = {"id": 1, "user": 1, "status": "closed"}
+        mock_bug, mock_qs = _make_mock_bug_qs()
+        mock_qs.get = AsyncMock(side_effect=[bug, updated])
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed"}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 200
+        assert resp.data["success"] is True
+        assert resp.data["data"]["status"] == "closed"
+        mock_qs.update.assert_called_once_with(status="closed")
+
+    async def test_update_verified_converts_to_int(self):
+        bug = {"id": 1, "user": 1, "status": "open", "verified": 0}
+        updated = {"id": 1, "user": 1, "status": "open", "verified": 1}
+        mock_bug, mock_qs = _make_mock_bug_qs()
+        mock_qs.get = AsyncMock(side_effect=[bug, updated])
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"verified": True}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 200
+        mock_qs.update.assert_called_once_with(verified=1)
+
+    async def test_update_multiple_fields(self):
+        bug = {"id": 1, "user": 1, "status": "open", "score": 10}
+        updated = {"id": 1, "user": 1, "status": "closed", "score": 90}
+        mock_bug, mock_qs = _make_mock_bug_qs()
+        mock_qs.get = AsyncMock(side_effect=[bug, updated])
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed", "score": 90}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 200
+        mock_qs.update.assert_called_once_with(status="closed", score=90)
+
+    async def test_immutable_fields_ignored(self):
+        """Fields like id, created, user should be silently ignored."""
+        bug = {"id": 1, "user": 1, "status": "open"}
+        updated = {"id": 1, "user": 1, "status": "closed"}
+        mock_bug, mock_qs = _make_mock_bug_qs()
+        mock_qs.get = AsyncMock(side_effect=[bug, updated])
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed", "id": 999, "created": "2020-01-01", "user": 99}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 200
+        # Only status should be in the update call, not id/created/user
+        mock_qs.update.assert_called_once_with(status="closed")
+
+    async def test_null_string_field_accepted(self):
+        bug = {"id": 1, "user": 1, "github_url": "https://old.com"}
+        updated = {"id": 1, "user": 1, "github_url": None}
+        mock_bug, mock_qs = _make_mock_bug_qs()
+        mock_qs.get = AsyncMock(side_effect=[bug, updated])
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"github_url": None}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 200
+        mock_qs.update.assert_called_once_with(github_url=None)
+
+    async def test_bug_with_null_user_allows_any_authenticated_user(self):
+        """Bugs with no owner (user=None) can be updated by any authenticated user."""
+        bug = {"id": 1, "user": None, "status": "open"}
+        updated = {"id": 1, "user": None, "status": "closed"}
+        mock_bug, mock_qs = _make_mock_bug_qs()
+        mock_qs.get = AsyncMock(side_effect=[bug, updated])
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed"}, headers=_make_auth_header(5)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 200
+
+    async def test_db_error_returns_500(self):
+        with patch("handlers.bugs.get_db_safe", AsyncMock(side_effect=Exception("DB down"))):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed"}, headers=_make_auth_header()),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
         assert resp.status == 500

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -491,6 +491,18 @@ class TestUpdateBug:
             )
         assert resp.status == 403
 
+    async def test_null_owner_returns_403(self):
+        bug = {"id": 1, "user": None, "status": "open"}
+        mock_bug, _ = _make_mock_bug_qs(get_return=bug)
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"status": "closed"}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 403
+
     # -- Success tests --
 
     async def test_update_status_success(self):
@@ -573,11 +585,9 @@ class TestUpdateBug:
         mock_qs.update.assert_called_once_with(github_url=None)
 
     async def test_bug_with_null_user_allows_any_authenticated_user(self):
-        """Bugs with no owner (user=None) can be updated by any authenticated user."""
+        """Bugs with no owner (user=None) cannot be updated by anyone."""
         bug = {"id": 1, "user": None, "status": "open"}
-        updated = {"id": 1, "user": None, "status": "closed"}
-        mock_bug, mock_qs = _make_mock_bug_qs()
-        mock_qs.get = AsyncMock(side_effect=[bug, updated])
+        mock_bug, _ = _make_mock_bug_qs(get_return=bug)
         db = MockDB()
         with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
              patch("handlers.bugs.Bug", mock_bug):
@@ -585,7 +595,7 @@ class TestUpdateBug:
                 MockRequest(method="PATCH", body={"status": "closed"}, headers=_make_auth_header(5)),
                 MockEnv(), {"id": "1"}, {}, "/bugs/1",
             )
-        assert resp.status == 200
+        assert resp.status == 403
 
     async def test_db_error_returns_500(self):
         with patch("handlers.bugs.get_db_safe", AsyncMock(side_effect=Exception("DB down"))):

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -584,7 +584,7 @@ class TestUpdateBug:
         assert resp.status == 200
         mock_qs.update.assert_called_once_with(github_url=None)
 
-    async def test_bug_with_null_user_allows_any_authenticated_user(self):
+    async def test_null_owner_denies_any_authenticated_user(self):
         """Bugs with no owner (user=None) cannot be updated by anyone."""
         bug = {"id": 1, "user": None, "status": "open"}
         mock_bug, _ = _make_mock_bug_qs(get_return=bug)

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -454,6 +454,18 @@ class TestUpdateBug:
             )
         assert resp.status == 400
 
+    async def test_bool_as_score_returns_400(self):
+        bug = {"id": 1, "user": 1, "status": "open"}
+        mock_bug, _ = _make_mock_bug_qs(get_return=bug)
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)), \
+             patch("handlers.bugs.Bug", mock_bug):
+            resp = await handle_bugs(
+                MockRequest(method="PATCH", body={"score": True}, headers=_make_auth_header(1)),
+                MockEnv(), {"id": "1"}, {}, "/bugs/1",
+            )
+        assert resp.status == 400
+
     # -- Not found / authorization tests --
 
     async def test_bug_not_found_returns_404(self):


### PR DESCRIPTION
## Summary
Adds `PATCH /bugs/{id}` endpoint for updating bug reports. Requires JWT auth — only the bug owner can update.
## Changes
- **`src/handlers/bugs.py`** — `update_bug()` with JWT auth, owner-only authorization, field whitelist validation, and ORM-based updates
- **`src/main.py`** — Registered PATCH route (base + `/v2`)
- **`tests/test_bugs.py`** — 18 new tests (auth, validation, authorization, success cases)
**Updatable fields:** `status`, `verified`, `score`, `description`, `markdown_description`, `github_url`, `cve_id`, `cve_score`, `is_hidden`, `closed_by`, `closed_date`, `label`
**Valid statuses:** `open`, `closed`, `in-progress`, `reviewing`
## Tests
210 passed (192 existing + 18 new), 0 regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PATCH endpoint to update bugs with JWT-based auth; owners can modify status, verification, visibility, score, URLs, and nullable text fields.
* **Bug Fixes**
  * Improved validation and clear error responses for invalid input, missing/invalid auth, forbidden updates, not-found bugs, and server errors.
* **Tests**
  * Expanded tests for auth, validation, authorization, success cases, and backend error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->