### PR TITLE
feat: implement rate limiting for auth and bugs handlers

### DIFF
--- a/src/handlers/auth.py
+++ b/src/handlers/auth.py
@@ -13,11 +13,18 @@ from libs.data_protection import encrypt_sensitive, decrypt_sensitive, blind_ind
 from services.email_service import EmailService
 from workers import Response
 from models import User
+from libs.rate_limit import get_client_ip, is_rate_limited
 
 import logging
 
 _USERNAME_RE = re.compile(r'^[a-zA-Z0-9_.-]{3,30}$')
 _EMAIL_RE = re.compile(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
+
+AUTH_RATE_LIMIT: Dict[str, list] = {}
+_RATE_LIMIT_WINDOW_SECONDS = 60
+_RATE_LIMIT_MAX_REQUESTS = 2
+
+
 def generate_jwt_token(user_id: int, secret: str, expires_in: int = 3600) -> str:
     """
     Generate a JWT authentication token for a user.
@@ -76,6 +83,10 @@ async def handle_signup(
     if method != "POST":
         return error_response( "Method Not Allowed", 405, headers={"Allow": "POST"})
     try: 
+        client_ip = get_client_ip(request)
+        if is_rate_limited(client_ip, AUTH_RATE_LIMIT, _RATE_LIMIT_WINDOW_SECONDS, _RATE_LIMIT_MAX_REQUESTS):
+            return error_response("Too many requests. Please try again later.", status=429)
+
         body = await parse_json_body(request)
         if not body:
             return error_response("Invalid JSON body", 400)
@@ -247,6 +258,11 @@ async def handle_signin(request: Any, env: Any, path_params: Dict[str, str], que
         method = str(request.method).upper()
         if method != "POST":
             return error_response("Method Not Allowed", 405, headers={"Allow": "POST"})
+
+        client_ip = get_client_ip(request)
+        if is_rate_limited(client_ip, AUTH_RATE_LIMIT, _RATE_LIMIT_WINDOW_SECONDS, _RATE_LIMIT_MAX_REQUESTS):
+            return error_response("Too many requests. Please try again later.", status=429)
+
         body = await parse_json_body(request)
         if not body:
             return error_response("Invalid JSON body", 400) 

--- a/src/handlers/auth.py
+++ b/src/handlers/auth.py
@@ -20,9 +20,11 @@ import logging
 _USERNAME_RE = re.compile(r'^[a-zA-Z0-9_.-]{3,30}$')
 _EMAIL_RE = re.compile(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
 
-AUTH_RATE_LIMIT: Dict[str, list] = {}
+SIGNUP_RATE_LIMIT: Dict[str, list] = {}
+SIGNIN_RATE_LIMIT: Dict[str, list] = {}
 _RATE_LIMIT_WINDOW_SECONDS = 60
-_RATE_LIMIT_MAX_REQUESTS = 2
+_SIGNUP_MAX_REQUESTS = 5
+_SIGNIN_MAX_REQUESTS = 10
 
 
 def generate_jwt_token(user_id: int, secret: str, expires_in: int = 3600) -> str:
@@ -84,7 +86,7 @@ async def handle_signup(
         return error_response( "Method Not Allowed", 405, headers={"Allow": "POST"})
     try: 
         client_ip = get_client_ip(request)
-        if is_rate_limited(client_ip, AUTH_RATE_LIMIT, _RATE_LIMIT_WINDOW_SECONDS, _RATE_LIMIT_MAX_REQUESTS):
+        if is_rate_limited(client_ip, SIGNUP_RATE_LIMIT, _RATE_LIMIT_WINDOW_SECONDS, _SIGNUP_MAX_REQUESTS):
             return error_response("Too many requests. Please try again later.", status=429)
 
         body = await parse_json_body(request)
@@ -260,7 +262,7 @@ async def handle_signin(request: Any, env: Any, path_params: Dict[str, str], que
             return error_response("Method Not Allowed", 405, headers={"Allow": "POST"})
 
         client_ip = get_client_ip(request)
-        if is_rate_limited(client_ip, AUTH_RATE_LIMIT, _RATE_LIMIT_WINDOW_SECONDS, _RATE_LIMIT_MAX_REQUESTS):
+        if is_rate_limited(client_ip, SIGNIN_RATE_LIMIT, _RATE_LIMIT_WINDOW_SECONDS, _SIGNIN_MAX_REQUESTS):
             return error_response("Too many requests. Please try again later.", status=429)
 
         body = await parse_json_body(request)

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -12,7 +12,7 @@ from libs.rate_limit import get_client_ip, is_rate_limited
 
 BUG_RATE_LIMIT: Dict[str, list] = {}
 _RATE_LIMIT_WINDOW_SECONDS = 60
-_RATE_LIMIT_MAX_REQUESTS = 2
+_RATE_LIMIT_MAX_REQUESTS = 10
 
 async def handle_bugs(
     request: Any,

--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -8,6 +8,11 @@ from libs.db import get_db_safe
 from models import Bug
 from workers import Response
 import logging
+from libs.rate_limit import get_client_ip, is_rate_limited
+
+BUG_RATE_LIMIT: Dict[str, list] = {}
+_RATE_LIMIT_WINDOW_SECONDS = 60
+_RATE_LIMIT_MAX_REQUESTS = 2
 
 async def handle_bugs(
     request: Any,
@@ -47,6 +52,8 @@ async def handle_bugs(
     except Exception as e:
         logger.error(f"Database connection error: {str(e)}")
         return error_response(f"Database connection error: {str(e)}", status=500)
+
+    client_ip = get_client_ip(request)
     
     if path.endswith("/search"):
         query = query_params.get("q", "")
@@ -178,6 +185,9 @@ async def handle_bugs(
     
     # Create bug
     if method == "POST":
+        if is_rate_limited(client_ip, BUG_RATE_LIMIT, _RATE_LIMIT_WINDOW_SECONDS, _RATE_LIMIT_MAX_REQUESTS):
+            return error_response("Too many requests. Please try again later.", status=429)
+
         body = await parse_json_body(request)
         
         if not body:

--- a/src/libs/rate_limit.py
+++ b/src/libs/rate_limit.py
@@ -1,0 +1,41 @@
+from typing import Any, Dict
+import time
+
+def get_header(request: Any, name: str) -> str:
+    """Safely read a request header in Workers and tests"""
+    headers = getattr(request, "headers", None)
+    if headers and hasattr(headers, "get"):
+        value = headers.get(name)
+        return str(value) if value is not None else ""
+    return ""
+
+
+def get_client_ip(request: Any) -> str:
+    """Extract the real client IP from headers"""
+    ip = get_header(request, "CF-Connecting-IP").strip()
+    if not ip:
+        xff = get_header(request, "X-Forwarded-For")
+        ip = xff.split(",")[0].strip() if xff else ""
+    return ip or "unknown"
+
+def is_rate_limited(client_key: str, rate_limit_dict: Dict[str, list], rate_limit_window_seconds: int, rate_limit_max_requests: int) -> bool:
+    """Sliding-window in-memory rate limiter"""
+    now = time.time()
+    window_start = now - rate_limit_window_seconds
+
+    attempts = rate_limit_dict.get(client_key, [])
+    attempts = [ts for ts in attempts if ts >= window_start]
+
+    stale_keys = [key for key, timestamps in rate_limit_dict.items() if not timestamps or timestamps[-1] < window_start]
+    for key in stale_keys:
+        if key != client_key:
+            rate_limit_dict.pop(key, None)
+
+    if len(attempts) >= rate_limit_max_requests:
+        rate_limit_dict[client_key] = attempts
+        return True
+
+    attempts.append(now)
+    rate_limit_dict[client_key] = attempts
+    return False
+

--- a/src/libs/rate_limit.py
+++ b/src/libs/rate_limit.py
@@ -57,16 +57,17 @@ def is_rate_limited(client_key: str, rate_limit_dict: Dict[str, list], rate_limi
     attempts = rate_limit_dict.get(client_key, [])
     attempts = [ts for ts in attempts if ts >= window_start]
 
-    last_sweep = rate_limit_dict.get("__last_sweep__", [0.0])
+    _SWEEP_KEY = "\x00__last_sweep__"
+    last_sweep = rate_limit_dict.get(_SWEEP_KEY, [0.0])
     if now - last_sweep[0] >= rate_limit_window_seconds:
         stale_keys = [
             key for key, timestamps in rate_limit_dict.items()
-            if key != "__last_sweep__" and key != client_key
+            if key != _SWEEP_KEY and key != client_key
             and (not timestamps or timestamps[-1] < window_start)
         ]
         for key in stale_keys:
             rate_limit_dict.pop(key, None)
-        rate_limit_dict["__last_sweep__"] = [now]
+        rate_limit_dict[_SWEEP_KEY] = [now]
 
     if len(attempts) >= rate_limit_max_requests:
         rate_limit_dict[client_key] = attempts

--- a/src/libs/rate_limit.py
+++ b/src/libs/rate_limit.py
@@ -1,5 +1,10 @@
 from typing import Any, Dict
+import logging
 import time
+import uuid
+
+
+logger = logging.getLogger(__name__)
 
 def get_header(request: Any, name: str) -> str:
     """Safely read a request header in Workers and tests"""
@@ -16,7 +21,33 @@ def get_client_ip(request: Any) -> str:
     if not ip:
         xff = get_header(request, "X-Forwarded-For")
         ip = xff.split(",")[0].strip() if xff else ""
-    return ip or "unknown"
+    if ip:
+        return ip
+
+    # Avoid a shared fallback bucket when IP headers are unavailable.
+    request_id = get_header(request, "X-Request-ID").strip()
+    remote_addr = str(getattr(request, "remote_addr", "") or "").strip()
+
+    logger.warning(
+        "Missing client IP headers: CF-Connecting-IP and X-Forwarded-For are absent"
+    )
+
+    if request_id:
+        return request_id
+    if remote_addr:
+        return remote_addr
+
+    existing_fallback = str(getattr(request, "_rate_limit_fallback_key", "") or "").strip()
+    if existing_fallback:
+        return existing_fallback
+
+    fallback = f"anon-{uuid.uuid4().hex[:10]}"
+    try:
+        setattr(request, "_rate_limit_fallback_key", fallback)
+    except Exception:
+        # Some request implementations may not allow dynamic attributes.
+        pass
+    return fallback
 
 def is_rate_limited(client_key: str, rate_limit_dict: Dict[str, list], rate_limit_window_seconds: int, rate_limit_max_requests: int) -> bool:
     """Sliding-window in-memory rate limiter"""
@@ -26,10 +57,16 @@ def is_rate_limited(client_key: str, rate_limit_dict: Dict[str, list], rate_limi
     attempts = rate_limit_dict.get(client_key, [])
     attempts = [ts for ts in attempts if ts >= window_start]
 
-    stale_keys = [key for key, timestamps in rate_limit_dict.items() if not timestamps or timestamps[-1] < window_start]
-    for key in stale_keys:
-        if key != client_key:
+    last_sweep = rate_limit_dict.get("__last_sweep__", [0.0])
+    if now - last_sweep[0] >= rate_limit_window_seconds:
+        stale_keys = [
+            key for key, timestamps in rate_limit_dict.items()
+            if key != "__last_sweep__" and key != client_key
+            and (not timestamps or timestamps[-1] < window_start)
+        ]
+        for key in stale_keys:
             rate_limit_dict.pop(key, None)
+        rate_limit_dict["__last_sweep__"] = [now]
 
     if len(attempts) >= rate_limit_max_requests:
         rate_limit_dict[client_key] = attempts

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -36,7 +36,7 @@ sys.modules["workers"] = _mock_workers
 # Removed sys.modules.js mock to allow utils.py fallback
 
 
-from handlers.auth import handle_signin, handle_signup, handle_verify_email  # noqa: E402
+from handlers.auth import handle_signin, handle_signup, handle_verify_email, AUTH_RATE_LIMIT  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -75,6 +75,16 @@ class MockEnv:
     BLT_API_BASE_URL = "http://localhost:8787"
     MAILGUN_API_KEY = "test-key"
     MAILGUN_DOMAIN = "test.mailgun.org"
+    SENDGRID_USERNAME = "test-sendgrid-user"
+    SENDGRID_PASSWORD = "test-sendgrid-pass"
+    FROM_EMAIL = "noreply@example.com"
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limits():
+    AUTH_RATE_LIMIT.clear()
+    yield
+    AUTH_RATE_LIMIT.clear()
 
 
 def _make_mock_user(is_active=True, password="testpass123456"):
@@ -228,6 +238,30 @@ class TestSigninValidation:
 
         assert resp.status == 500
 
+    @pytest.mark.asyncio
+    async def test_signin_is_rate_limited_after_burst(self):
+        user = _make_mock_user(is_active=True)
+        mock_user_cls = MagicMock()
+        mock_qs = MagicMock()
+        mock_qs.filter.return_value = mock_qs
+        mock_qs.first = AsyncMock(return_value=user)
+        mock_user_cls.objects.return_value = mock_qs
+
+        body = {"username": "testuser", "password": "testpass123456"}
+        request = MockRequest(method="POST", body=body)
+
+        with patch("handlers.auth.get_db_safe", AsyncMock(return_value=MagicMock())), \
+             patch("handlers.auth.User", mock_user_cls), \
+             patch("handlers.auth.__HASHING_ITERATIONS", HASHING_ITERATIONS), \
+             patch("handlers.auth.create_access_token", return_value="fake.jwt.token"):
+            first = await handle_signin(request, MockEnv(), {}, {}, "/auth/signin")
+            second = await handle_signin(request, MockEnv(), {}, {}, "/auth/signin")
+            third = await handle_signin(request, MockEnv(), {}, {}, "/auth/signin")
+
+        assert first.status == 200
+        assert second.status == 200
+        assert third.status == 429
+
 
 # ─── handle_signup tests ────────────────────────────────────────────────
 
@@ -253,6 +287,36 @@ class TestSignupValidation:
         with patch("handlers.auth.check_required_fields", AsyncMock(return_value=(False, "email"))):
             resp = await handle_signup(request, MockEnv(), {}, {}, "/auth/signup")
         assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_signup_is_rate_limited_after_burst(self):
+        body = {"username": "user123", "password": "Testpass123456!", "email": "user@example.com"}
+        request = MockRequest(method="POST", body=body)
+
+        with patch("handlers.auth.get_db_safe", AsyncMock(return_value=MagicMock())), \
+             patch("handlers.auth.check_required_fields", AsyncMock(return_value=(True, None))), \
+             patch("handlers.auth.blind_index", side_effect=lambda value, *_args, **_kwargs: f"{value}-hash"), \
+             patch("handlers.auth.encrypt_sensitive", side_effect=lambda value, *_args, **_kwargs: value), \
+             patch("handlers.auth.User") as mock_user_cls, \
+             patch("handlers.auth.EmailService") as mock_email_service, \
+             patch("handlers.auth.generate_jwt_token", return_value="fake.token"):
+            mock_qs = MagicMock()
+            mock_qs.filter.return_value = mock_qs
+            mock_qs.first = AsyncMock(return_value=None)
+            mock_qs.delete = AsyncMock()
+            mock_user_cls.objects.return_value = mock_qs
+            mock_user_cls.create = AsyncMock(return_value={"id": 1})
+            email_instance = MagicMock()
+            email_instance.send_verification_email = AsyncMock(return_value=(200, "ok"))
+            mock_email_service.return_value = email_instance
+
+            first = await handle_signup(request, MockEnv(), {}, {}, "/auth/signup")
+            second = await handle_signup(request, MockEnv(), {}, {}, "/auth/signup")
+            third = await handle_signup(request, MockEnv(), {}, {}, "/auth/signup")
+
+        assert first.status == 201
+        assert second.status == 201
+        assert third.status == 429
 
 
 # ─── handle_verify_email tests ──────────────────────────────────────────

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -36,7 +36,7 @@ sys.modules["workers"] = _mock_workers
 # Removed sys.modules.js mock to allow utils.py fallback
 
 
-from handlers.auth import handle_signin, handle_signup, handle_verify_email, AUTH_RATE_LIMIT  # noqa: E402
+from handlers.auth import handle_signin, handle_signup, handle_verify_email, SIGNUP_RATE_LIMIT, SIGNIN_RATE_LIMIT  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -82,9 +82,11 @@ class MockEnv:
 
 @pytest.fixture(autouse=True)
 def reset_rate_limits():
-    AUTH_RATE_LIMIT.clear()
+    SIGNUP_RATE_LIMIT.clear()
+    SIGNIN_RATE_LIMIT.clear()
     yield
-    AUTH_RATE_LIMIT.clear()
+    SIGNUP_RATE_LIMIT.clear()
+    SIGNIN_RATE_LIMIT.clear()
 
 
 def _make_mock_user(is_active=True, password="testpass123456"):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -241,7 +241,8 @@ class TestSigninValidation:
         assert resp.status == 500
 
     @pytest.mark.asyncio
-    async def test_signin_is_rate_limited_after_burst(self):
+    async def test_signin_is_rate_limited_after_burst(self, monkeypatch):
+        monkeypatch.setattr("handlers.auth._SIGNIN_MAX_REQUESTS", 2)
         user = _make_mock_user(is_active=True)
         mock_user_cls = MagicMock()
         mock_qs = MagicMock()
@@ -291,7 +292,8 @@ class TestSignupValidation:
         assert resp.status == 400
 
     @pytest.mark.asyncio
-    async def test_signup_is_rate_limited_after_burst(self):
+    async def test_signup_is_rate_limited_after_burst(self, monkeypatch):
+        monkeypatch.setattr("handlers.auth._SIGNUP_MAX_REQUESTS", 2)
         body = {"username": "user123", "password": "Testpass123456!", "email": "user@example.com"}
         request = MockRequest(method="POST", body=body)
 

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -254,9 +254,13 @@ class TestCreateBug:
         assert resp.status == 201
         assert resp.data["success"] is True
 
-    async def test_create_bug_is_rate_limited_after_burst(self):
+    async def test_create_bug_is_rate_limited_after_burst(self, monkeypatch):
+        monkeypatch.setattr("handlers.bugs._RATE_LIMIT_MAX_REQUESTS", 2)
         db = MockDB()
-        db.queue_first({"id": 1}, {"id": 1, "url": "https://example.com", "description": "d"})
+        db.queue_first(
+            {"id": 1}, {"id": 1, "url": "https://example.com", "description": "d"},
+            {"id": 2}, {"id": 2, "url": "https://example.com", "description": "d"},
+        )
         request = MockRequest(method="POST", body={"url": "https://example.com", "description": "d"})
 
         with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)):

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -26,7 +26,7 @@ sys.modules["workers"] = _mock_workers
 
 # Removed sys.modules.js mock for same reason as test_auth
 
-from handlers.bugs import handle_bugs  # noqa: E402
+from handlers.bugs import handle_bugs, BUG_RATE_LIMIT  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -111,6 +111,13 @@ class MockRequest:
 
 class MockEnv:
     pass
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limits():
+    BUG_RATE_LIMIT.clear()
+    yield
+    BUG_RATE_LIMIT.clear()
 
 
 def _make_mock_bug_class(count=0):
@@ -246,6 +253,20 @@ class TestCreateBug:
             resp = await handle_bugs(MockRequest(method="POST", body={"url": "https://example.com", "description": "d"}), MockEnv(), {}, {}, "/bugs")
         assert resp.status == 201
         assert resp.data["success"] is True
+
+    async def test_create_bug_is_rate_limited_after_burst(self):
+        db = MockDB()
+        db.queue_first({"id": 1}, {"id": 1, "url": "https://example.com", "description": "d"})
+        request = MockRequest(method="POST", body={"url": "https://example.com", "description": "d"})
+
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)):
+            first = await handle_bugs(request, MockEnv(), {}, {}, "/bugs")
+            second = await handle_bugs(request, MockEnv(), {}, {}, "/bugs")
+            third = await handle_bugs(request, MockEnv(), {}, {}, "/bugs")
+
+        assert first.status == 201
+        assert second.status == 201
+        assert third.status == 429
 
 
 class TestListBugs:


### PR DESCRIPTION
Adds in-memory sliding-window rate limiting to authentication and bug submission endpoints to reduce brute-force and spam risk.

### What changed
- Added rate limiting for sign-up and sign-in handlers.
- Added rate limiting for bug creation handler.
- Reused shared rate-limit utilities for client IP extraction and throttling logic.
- Added stale-entry cleanup in the rate-limit helper to avoid unbounded dictionary growth.
- Added/updated tests to validate 429 behavior after burst requests and ensure existing flows still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to signup, signin, and bug-report endpoints; excessive requests now receive HTTP 429 responses.
* **Tests**
  * Expanded automated tests to cover rate-limit behavior and ensure limits are reset between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->