### PR TITLE
feat: Add shared static API key authentication

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,7 +5,7 @@
 # Shared defaults
 BLT_API_BASE_URL=https://api.owaspblt.org/v2
 BLT_WEBSITE_URL=https://owaspblt.org
-BLT_API_KEY=replace_with_documented_shared_api_key
+BLT_API_KEY=f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051
 JWT_SECRET=your_jwt_secret_here
 USER_DATA_ENCRYPTION_KEY=your_user_data_encryption_key_here
 USER_DATA_HASH_KEY=your_user_data_hash_key_here

--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,7 @@
 # Shared defaults
 BLT_API_BASE_URL=https://api.owaspblt.org/v2
 BLT_WEBSITE_URL=https://owaspblt.org
+BLT_API_KEY=replace_with_documented_shared_api_key
 JWT_SECRET=your_jwt_secret_here
 USER_DATA_ENCRYPTION_KEY=your_user_data_encryption_key_here
 USER_DATA_HASH_KEY=your_user_data_hash_key_here
@@ -13,4 +14,3 @@ SENDGRID_PASSWORD=your_sendgrid_api_key_here
 FROM_EMAIL=support@owaspblt.org
 # Comma-separated allowed redirect URIs for signup/signin
 ALLOWED_REDIRECT_URIS=https://owaspblt.org,https://www.owaspblt.org
-

--- a/README.md
+++ b/README.md
@@ -690,14 +690,14 @@ wrangler deploy --no-build
 Protected endpoints require the shared BLT API key in the `X-BLT-API-Key` request header. Keep user auth separate: routes that need a signed-in user can still use the existing `Authorization` token header in addition to the shared key.
 
 ```bash
-curl -H "X-BLT-API-Key: YOUR_BLT_API_KEY" https://your-worker.workers.dev/bugs
+curl -H "X-BLT-API-Key: f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051" https://your-worker.workers.dev/bugs
 ```
 
 For endpoints that also require a user token:
 
 ```bash
 curl \
-  -H "X-BLT-API-Key: YOUR_BLT_API_KEY" \
+  -H "X-BLT-API-Key: f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051" \
   -H "Authorization: Token YOUR_API_TOKEN" \
   https://your-worker.workers.dev/bugs
 ```

--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Configure these in `.env.sample` (copy to `.env` for local development) and set 
 |----------|-------------|---------|
 | `BLT_API_BASE_URL` | BLT backend API URL | `https://api.owaspblt.org/v2` |
 | `BLT_WEBSITE_URL` | BLT website URL | `https://owaspblt.org` |
+| `BLT_API_KEY` | Shared static API key required for protected API routes | Required |
 | `JWT_SECRET` | Secret key for JWT tokens | Required |
 | `USER_DATA_ENCRYPTION_KEY` | Key used to encrypt sensitive user fields | Required for encrypted user data |
 | `USER_DATA_HASH_KEY` | Key used for user-data blind indexes (e.g., email hash) | Required for encrypted user data |
@@ -686,10 +687,19 @@ wrangler deploy --no-build
 
 ## Authentication
 
-Some endpoints require authentication. Pass the auth token in the request header:
+Protected endpoints require the shared BLT API key in the `X-BLT-API-Key` request header. Keep user auth separate: routes that need a signed-in user can still use the existing `Authorization` token header in addition to the shared key.
 
 ```bash
-curl -H "Authorization: Token YOUR_API_TOKEN" https://your-worker.workers.dev/bugs
+curl -H "X-BLT-API-Key: YOUR_BLT_API_KEY" https://your-worker.workers.dev/bugs
+```
+
+For endpoints that also require a user token:
+
+```bash
+curl \
+  -H "X-BLT-API-Key: YOUR_BLT_API_KEY" \
+  -H "Authorization: Token YOUR_API_TOKEN" \
+  https://your-worker.workers.dev/bugs
 ```
 
 ## Rate Limiting

--- a/docs/superpowers/plans/static-api-key.md
+++ b/docs/superpowers/plans/static-api-key.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a shared static API key gate to BLT API so external users include one documented key on API requests to `api.owaspblt.org`.
 
-**Architecture:** Store the expected key in the Worker environment as `BLT_API_KEY`. Clients send it in `X-BLT-API-Key`. The Worker entrypoint validates the key before dispatching to the router, with only docs, health, and CORS preflight left public.
+**Architecture:** Use the public shared key `f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051`. Clients send it in `X-BLT-API-Key`. The Worker entrypoint validates the key before dispatching to the router, with only docs, health, and CORS preflight left public.
 
 **Tech Stack:** Python 3.12, Cloudflare Workers Python runtime, existing custom router, pytest.
 
@@ -34,13 +34,13 @@
 Required request header:
 
 ```http
-X-BLT-API-Key: <shared-static-key>
+X-BLT-API-Key: f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051
 ```
 
 Expected environment variable:
 
 ```env
-BLT_API_KEY=<shared-static-key>
+BLT_API_KEY=f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051
 ```
 
 Public routes that do not require the shared key:
@@ -59,7 +59,7 @@ Failure behavior:
 
 - Missing key: `401` JSON error.
 - Invalid key: `401` JSON error.
-- `BLT_API_KEY` missing from env on a protected route: `500` JSON error, because the server is misconfigured.
+- The public shared key is accepted even when `BLT_API_KEY` is not configured locally.
 
 ## Implementation Checklist
 

--- a/docs/superpowers/plans/static-api-key.md
+++ b/docs/superpowers/plans/static-api-key.md
@@ -1,0 +1,87 @@
+# Static API Key Implementation Plan
+
+> **For agentic workers:** Use this file as the working context and checklist for the static API-key feature. Keep the checkbox state current as implementation progresses.
+
+**Goal:** Add a shared static API key gate to BLT API so external users include one documented key on API requests to `api.owaspblt.org`.
+
+**Architecture:** Store the expected key in the Worker environment as `BLT_API_KEY`. Clients send it in `X-BLT-API-Key`. The Worker entrypoint validates the key before dispatching to the router, with only docs, health, and CORS preflight left public.
+
+**Tech Stack:** Python 3.12, Cloudflare Workers Python runtime, existing custom router, pytest.
+
+---
+
+## Context
+
+- Current entrypoint: `src/main.py`
+- Current route dispatcher: `src/router.py`
+- Current auth handlers: `src/handlers/auth.py`
+- Current client wrapper: `src/client.py`
+- Current public docs page: `src/pages/index.html`
+- Current env sample: `.env.sample`
+- Current README auth docs mention `Authorization: Token YOUR_API_TOKEN`, but there is no shared API-key enforcement yet.
+- Baseline verification before feature work: `uv run --extra dev pytest -q` passed with `195 passed`.
+- Current branch when this plan was created: `feat/add-api-key`.
+
+## Product Decision
+
+- Use maintainer-approved option 2: one shared/static API key for now.
+- This is not per-user API-key management.
+- Do not add database tables, migrations, user profile API-key screens, key creation, or key rotation endpoints in this pass.
+- Keep JWT/user auth separate from this shared API-key gate.
+
+## API Contract
+
+Required request header:
+
+```http
+X-BLT-API-Key: <shared-static-key>
+```
+
+Expected environment variable:
+
+```env
+BLT_API_KEY=<shared-static-key>
+```
+
+Public routes that do not require the shared key:
+
+- `OPTIONS` requests
+- `GET /`
+- `GET /v2`
+- `GET /health`
+- `GET /v2/health`
+
+Protected routes:
+
+- All other current and future routes, including `/routes`, `/auth/signup`, `/auth/signin`, and data endpoints.
+
+Failure behavior:
+
+- Missing key: `401` JSON error.
+- Invalid key: `401` JSON error.
+- `BLT_API_KEY` missing from env on a protected route: `500` JSON error, because the server is misconfigured.
+
+## Implementation Checklist
+
+- [x] Capture repo context and baseline state in this MD file.
+- [x] Add failing tests for API-key helper behavior.
+- [x] Add failing tests for Worker entrypoint enforcement.
+- [x] Add failing tests for client header support.
+- [x] Implement `src/libs/api_key.py`.
+- [x] Wire API-key enforcement into `src/main.py` before router dispatch.
+- [x] Update CORS allowed headers to include `X-BLT-API-Key`.
+- [x] Update `BLTClient` to optionally send `X-BLT-API-Key`.
+- [x] Update `.env.sample`.
+- [x] Update README authentication documentation.
+- [x] Update homepage authentication snippet.
+- [x] Run focused tests.
+- [x] Run full test suite.
+
+## Out of Scope
+
+- Per-user API keys.
+- API-key persistence in D1.
+- Admin UI for creating/revoking keys.
+- Rate limiting keyed by API key.
+- Multiple active keys or rotation windows.
+- Replacing JWT auth.

--- a/scripts/test_static_api_key.sh
+++ b/scripts/test_static_api_key.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8787}"
+API_KEY="${BLT_API_KEY:-${API_KEY:-dev-static-api-key}}"
+PUBLIC_PATH="${PUBLIC_PATH:-/health}"
+PROTECTED_PATH="${PROTECTED_PATH:-/routes}"
+
+request() {
+  local label="$1"
+  local path="$2"
+  local expected_status="$3"
+  shift 3
+
+  local body_file
+  body_file="$(mktemp)"
+  local status
+  local curl_exit
+
+  set +e
+  status="$(curl -sS -o "$body_file" -w "%{http_code}" "$@" "${BASE_URL}${path}")"
+  curl_exit=$?
+  set -e
+
+  echo "== ${label} =="
+  echo "GET ${BASE_URL}${path}"
+  echo "HTTP ${status}"
+  cat "$body_file"
+  echo
+  if [[ "$curl_exit" -eq 0 && "$status" == "$expected_status" ]]; then
+    echo "PASS expected HTTP ${expected_status}"
+  else
+    echo "FAIL expected HTTP ${expected_status}"
+    failures=1
+  fi
+  echo
+  rm -f "$body_file"
+}
+
+failures=0
+
+echo "BLT API static key smoke test"
+echo "BASE_URL=${BASE_URL}"
+echo "PROTECTED_PATH=${PROTECTED_PATH}"
+echo
+
+request "Public route without API key" "$PUBLIC_PATH" "200"
+request "Protected route without API key" "$PROTECTED_PATH" "401"
+request "Protected route with wrong API key" "$PROTECTED_PATH" "401" -H "X-BLT-API-Key: wrong-key"
+request "Protected route with correct API key" "$PROTECTED_PATH" "200" -H "X-BLT-API-Key: ${API_KEY}"
+
+exit "$failures"

--- a/scripts/test_static_api_key.sh
+++ b/scripts/test_static_api_key.sh
@@ -1,71 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
-
 BASE_URL="${BASE_URL:-http://localhost:8787}"
 PUBLIC_PATH="${PUBLIC_PATH:-/health}"
 PROTECTED_PATH="${PROTECTED_PATH:-/routes}"
-
-read_env_value() {
-  local file="$1"
-  local key="$2"
-
-  [[ -f "$file" ]] || return 0
-
-  awk -F= -v key="$key" '
-    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
-    {
-      name = $1
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "", name)
-      if (name == key) {
-        value = substr($0, index($0, "=") + 1)
-        gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
-        if (value ~ /^".*"$/ || value ~ /^\047.*\047$/) {
-          value = substr(value, 2, length(value) - 2)
-        }
-        print value
-        exit
-      }
-    }
-  ' "$file"
-}
-
-resolve_api_key() {
-  if [[ -n "${BLT_API_KEY:-}" ]]; then
-    API_KEY="$BLT_API_KEY"
-    API_KEY_SOURCE="BLT_API_KEY environment variable"
-    return
-  fi
-
-  if [[ -n "${API_KEY:-}" ]]; then
-    API_KEY="$API_KEY"
-    API_KEY_SOURCE="API_KEY environment variable"
-    return
-  fi
-
-  local env_files=()
-  if [[ -n "${API_KEY_ENV_FILE:-}" ]]; then
-    env_files=("$API_KEY_ENV_FILE")
-  else
-    env_files=("$REPO_ROOT/.dev.vars" "$REPO_ROOT/.env.local" "$REPO_ROOT/.env")
-  fi
-
-  local env_file value
-  for env_file in "${env_files[@]}"; do
-    value="$(read_env_value "$env_file" "BLT_API_KEY")"
-    if [[ -n "$value" ]]; then
-      API_KEY="$value"
-      API_KEY_SOURCE="$env_file"
-      return
-    fi
-  done
-
-  echo "Error: BLT_API_KEY was not found." >&2
-  echo "Set BLT_API_KEY in your shell, API_KEY in your shell, or BLT_API_KEY in .dev.vars/.env.local/.env." >&2
-  exit 2
-}
+PUBLIC_BLT_API_KEY="f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051"
+API_KEY="${API_KEY:-$PUBLIC_BLT_API_KEY}"
 
 request() {
   local label="$1"
@@ -99,14 +39,11 @@ request() {
 }
 
 failures=0
-API_KEY=""
-API_KEY_SOURCE=""
-resolve_api_key
 
 echo "BLT API static key smoke test"
 echo "BASE_URL=${BASE_URL}"
 echo "PROTECTED_PATH=${PROTECTED_PATH}"
-echo "API key source: ${API_KEY_SOURCE}"
+echo "API key: ${API_KEY}"
 echo
 
 request "Public route without API key" "$PUBLIC_PATH" "200"

--- a/scripts/test_static_api_key.sh
+++ b/scripts/test_static_api_key.sh
@@ -1,10 +1,71 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
 BASE_URL="${BASE_URL:-http://localhost:8787}"
-API_KEY="${BLT_API_KEY:-${API_KEY:-dev-static-api-key}}"
 PUBLIC_PATH="${PUBLIC_PATH:-/health}"
 PROTECTED_PATH="${PROTECTED_PATH:-/routes}"
+
+read_env_value() {
+  local file="$1"
+  local key="$2"
+
+  [[ -f "$file" ]] || return 0
+
+  awk -F= -v key="$key" '
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    {
+      name = $1
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", name)
+      if (name == key) {
+        value = substr($0, index($0, "=") + 1)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+        if (value ~ /^".*"$/ || value ~ /^\047.*\047$/) {
+          value = substr(value, 2, length(value) - 2)
+        }
+        print value
+        exit
+      }
+    }
+  ' "$file"
+}
+
+resolve_api_key() {
+  if [[ -n "${BLT_API_KEY:-}" ]]; then
+    API_KEY="$BLT_API_KEY"
+    API_KEY_SOURCE="BLT_API_KEY environment variable"
+    return
+  fi
+
+  if [[ -n "${API_KEY:-}" ]]; then
+    API_KEY="$API_KEY"
+    API_KEY_SOURCE="API_KEY environment variable"
+    return
+  fi
+
+  local env_files=()
+  if [[ -n "${API_KEY_ENV_FILE:-}" ]]; then
+    env_files=("$API_KEY_ENV_FILE")
+  else
+    env_files=("$REPO_ROOT/.dev.vars" "$REPO_ROOT/.env.local" "$REPO_ROOT/.env")
+  fi
+
+  local env_file value
+  for env_file in "${env_files[@]}"; do
+    value="$(read_env_value "$env_file" "BLT_API_KEY")"
+    if [[ -n "$value" ]]; then
+      API_KEY="$value"
+      API_KEY_SOURCE="$env_file"
+      return
+    fi
+  done
+
+  echo "Error: BLT_API_KEY was not found." >&2
+  echo "Set BLT_API_KEY in your shell, API_KEY in your shell, or BLT_API_KEY in .dev.vars/.env.local/.env." >&2
+  exit 2
+}
 
 request() {
   local label="$1"
@@ -38,10 +99,14 @@ request() {
 }
 
 failures=0
+API_KEY=""
+API_KEY_SOURCE=""
+resolve_api_key
 
 echo "BLT API static key smoke test"
 echo "BASE_URL=${BASE_URL}"
 echo "PROTECTED_PATH=${PROTECTED_PATH}"
+echo "API key source: ${API_KEY_SOURCE}"
 echo
 
 request "Public route without API key" "$PUBLIC_PATH" "200"

--- a/src/client.py
+++ b/src/client.py
@@ -28,16 +28,23 @@ class BLTClient:
     Django backend API.
     """
     
-    def __init__(self, base_url: str, auth_token: Optional[str] = None):
+    def __init__(
+        self,
+        base_url: str,
+        auth_token: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
         """
         Initialize the BLT client.
         
         Args:
             base_url: Base URL of the BLT API
             auth_token: Optional authentication token
+            api_key: Optional shared BLT API key
         """
         self.base_url = base_url.rstrip("/")
         self.auth_token = auth_token
+        self.api_key = api_key
     
     def _get_headers(self, extra_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
         """Get default headers for requests."""
@@ -49,6 +56,9 @@ class BLTClient:
         
         if self.auth_token:
             headers["Authorization"] = f"Token {self.auth_token}"
+
+        if self.api_key:
+            headers["X-BLT-API-Key"] = self.api_key
         
         if extra_headers:
             headers.update(extra_headers)

--- a/src/handlers/homepage.py
+++ b/src/handlers/homepage.py
@@ -59,7 +59,7 @@ async def handle_homepage(
         "Content-Type": "text/html; charset=utf-8",
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Headers": "Content-Type, X-BLT-API-Key",
     }
     
     if _WORKERS_RUNTIME:

--- a/src/libs/api_key.py
+++ b/src/libs/api_key.py
@@ -1,0 +1,80 @@
+"""
+Shared static API-key validation for BLT API requests.
+"""
+
+import hmac
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+from utils import error_response
+
+
+API_KEY_HEADER = "X-BLT-API-Key"
+API_KEY_ENV_VAR = "BLT_API_KEY"
+PUBLIC_API_KEY_PATHS = {"/", "/v2", "/health", "/v2/health"}
+
+
+def _request_path(url: str) -> str:
+    """Normalize a request URL into the path used for API-key decisions."""
+    parsed = urlparse(str(url))
+    if (parsed.scheme or parsed.netloc) and not parsed.path:
+        path = "/"
+    else:
+        path = parsed.path or str(url).split("?", 1)[0]
+
+    if not path.startswith("/"):
+        path = f"/{path}"
+
+    if path != "/" and path.endswith("/"):
+        path = path[:-1]
+
+    return path
+
+
+def is_api_key_required(method: str, url: str) -> bool:
+    """Return whether a request method/path should require the shared API key."""
+    if str(method).upper() == "OPTIONS":
+        return False
+
+    return _request_path(url) not in PUBLIC_API_KEY_PATHS
+
+
+def _get_header(request: Any, name: str) -> str:
+    """Safely read a request header in Workers and local tests."""
+    headers = getattr(request, "headers", None)
+    if not headers or not hasattr(headers, "get"):
+        return ""
+
+    value = headers.get(name)
+    if value is None and isinstance(headers, dict):
+        for header_name, header_value in headers.items():
+            if str(header_name).lower() == name.lower():
+                value = header_value
+                break
+
+    return str(value) if value is not None else ""
+
+
+def validate_api_key_request(request: Any, env: Any) -> Optional[Any]:
+    """Validate the shared API key for protected requests.
+
+    Returns None when the request may continue, otherwise returns an error response.
+    """
+    method = str(getattr(request, "method", "GET"))
+    url = str(getattr(request, "url", "/"))
+
+    if not is_api_key_required(method, url):
+        return None
+
+    expected_key = str(getattr(env, API_KEY_ENV_VAR, "") or "").strip()
+    if not expected_key:
+        return error_response("API key authentication is not configured", status=500)
+
+    provided_key = _get_header(request, API_KEY_HEADER).strip()
+    if not provided_key:
+        return error_response("Missing API key", status=401)
+
+    if not hmac.compare_digest(provided_key, expected_key):
+        return error_response("Invalid API key", status=401)
+
+    return None

--- a/src/libs/api_key.py
+++ b/src/libs/api_key.py
@@ -11,6 +11,7 @@ from utils import error_response
 
 API_KEY_HEADER = "X-BLT-API-Key"
 API_KEY_ENV_VAR = "BLT_API_KEY"
+PUBLIC_BLT_API_KEY = "f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051"
 PUBLIC_API_KEY_PATHS = {"/", "/v2", "/health", "/v2/health"}
 
 
@@ -55,6 +56,15 @@ def _get_header(request: Any, name: str) -> str:
     return str(value) if value is not None else ""
 
 
+def _accepted_api_keys(env: Any) -> list[str]:
+    """Return public static key plus optional local override for compatibility."""
+    keys = [PUBLIC_BLT_API_KEY]
+    env_key = str(getattr(env, API_KEY_ENV_VAR, "") or "").strip()
+    if env_key and env_key not in keys:
+        keys.append(env_key)
+    return keys
+
+
 def validate_api_key_request(request: Any, env: Any) -> Optional[Any]:
     """Validate the shared API key for protected requests.
 
@@ -66,15 +76,12 @@ def validate_api_key_request(request: Any, env: Any) -> Optional[Any]:
     if not is_api_key_required(method, url):
         return None
 
-    expected_key = str(getattr(env, API_KEY_ENV_VAR, "") or "").strip()
-    if not expected_key:
-        return error_response("API key authentication is not configured", status=500)
-
     provided_key = _get_header(request, API_KEY_HEADER).strip()
     if not provided_key:
         return error_response("Missing API key", status=401)
 
-    if not hmac.compare_digest(provided_key, expected_key):
-        return error_response("Invalid API key", status=401)
+    for expected_key in _accepted_api_keys(env):
+        if hmac.compare_digest(provided_key, expected_key):
+            return None
 
-    return None
+    return error_response("Invalid API key", status=401)

--- a/src/main.py
+++ b/src/main.py
@@ -36,6 +36,7 @@ from handlers import (
 )
 from utils import json_response, error_response, cors_headers
 from libs.db import get_db_safe 
+from libs.api_key import validate_api_key_request
 
 # Initialize the router
 router = Router()
@@ -201,6 +202,10 @@ class Default(WorkerEntrypoint):
                     status=204,
                     headers=Headers.new(cors_headers())
                 )
+
+            api_key_error = validate_api_key_request(request, self.env)
+            if api_key_error is not None:
+                return api_key_error
 
             await get_db_safe(self.env)  # Ensure database is available and initialized
         

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -661,9 +661,18 @@
         <section class="bg-white rounded-lg shadow p-6 mb-8">
             <h2 class="text-3xl font-bold text-gray-900 mb-6 text-center">Authentication</h2>
             <div class="max-w-3xl mx-auto">
-                <p class="text-gray-600 text-center mb-4">Some endpoints require authentication. Include your API token in the Authorization header:</p>
+                <p class="text-gray-600 text-center mb-4">Protected endpoints require the shared BLT API key. Include it on API requests:</p>
                 <div class="bg-red-50 border border-red-200 rounded-lg p-4">
-                    <pre class="text-sm"><code class="text-gray-800">Authorization: Token YOUR_API_TOKEN</code></pre>
+                    <pre class="text-sm"><code class="text-gray-800">X-BLT-API-Key: YOUR_BLT_API_KEY</code></pre>
+                </div>
+                <p class="text-gray-600 text-center my-4">Set the same value in the Worker environment:</p>
+                <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                    <pre class="text-sm"><code class="text-gray-800">BLT_API_KEY=YOUR_BLT_API_KEY</code></pre>
+                </div>
+                <p class="text-gray-600 text-center my-4">Routes that also need a signed-in user can include the user token too:</p>
+                <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+                    <pre class="text-sm"><code class="text-gray-800">X-BLT-API-Key: YOUR_BLT_API_KEY
+Authorization: Token YOUR_API_TOKEN</code></pre>
                 </div>
             </div>
         </section>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -121,6 +121,11 @@
         <!-- API Endpoints Section -->
         <section class="bg-white rounded-lg shadow p-6 mb-8">
             <h2 class="text-3xl font-bold text-gray-900 mb-6 text-center">API Endpoints</h2>
+            <div class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+                <p class="text-sm font-semibold text-red-700 mb-2">Shared API key</p>
+                <pre class="text-xs overflow-x-auto"><code class="text-gray-800">X-BLT-API-Key: f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051</code></pre>
+                <p class="text-xs text-gray-600 mt-2">Try it requests use this shared key automatically.</p>
+            </div>
             
             <!-- Health & Status -->
             <div class="mb-8">
@@ -663,15 +668,15 @@
             <div class="max-w-3xl mx-auto">
                 <p class="text-gray-600 text-center mb-4">Protected endpoints require the shared BLT API key. Include it on API requests:</p>
                 <div class="bg-red-50 border border-red-200 rounded-lg p-4">
-                    <pre class="text-sm"><code class="text-gray-800">X-BLT-API-Key: YOUR_BLT_API_KEY</code></pre>
+                    <pre class="text-sm"><code class="text-gray-800">X-BLT-API-Key: f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051</code></pre>
                 </div>
                 <p class="text-gray-600 text-center my-4">Set the same value in the Worker environment:</p>
                 <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
-                    <pre class="text-sm"><code class="text-gray-800">BLT_API_KEY=YOUR_BLT_API_KEY</code></pre>
+                    <pre class="text-sm"><code class="text-gray-800">BLT_API_KEY=f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051</code></pre>
                 </div>
                 <p class="text-gray-600 text-center my-4">Routes that also need a signed-in user can include the user token too:</p>
                 <div class="bg-red-50 border border-red-200 rounded-lg p-4">
-                    <pre class="text-sm"><code class="text-gray-800">X-BLT-API-Key: YOUR_BLT_API_KEY
+                    <pre class="text-sm"><code class="text-gray-800">X-BLT-API-Key: f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051
 Authorization: Token YOUR_API_TOKEN</code></pre>
                 </div>
             </div>
@@ -736,6 +741,7 @@ Authorization: Token YOUR_API_TOKEN</code></pre>
                             <span class="text-sm font-semibold text-gray-700">URL:</span>
                             <code id="requestUrl" class="text-sm text-gray-800 ml-2"></code>
                         </div>
+                        <div id="apiKeyNotice" class="text-xs text-red-700 font-semibold mb-2"></div>
                         <div id="requestHeaders" class="text-xs text-gray-600"></div>
                     </div>
                 </div>
@@ -758,32 +764,28 @@ Authorization: Token YOUR_API_TOKEN</code></pre>
     <!-- JavaScript for API Testing -->
     <script>
         const baseUrl = '[[API_BASE_URL]]';
-        const apiKeyStorageKey = 'bltApiKey';
+        const sharedApiKey = 'f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051';
         const publicTryItEndpoints = new Set(['/', '/v2', '/health', '/v2/health']);
 
         function isPublicTryItEndpoint(endpoint) {
             return publicTryItEndpoints.has(endpoint.split('?')[0]);
         }
 
-        function getApiKeyHeaders(endpoint, promptIfMissing = true) {
+        function getApiKeyHeaders(endpoint) {
             if (isPublicTryItEndpoint(endpoint)) {
                 return {};
             }
 
-            let apiKey = localStorage.getItem(apiKeyStorageKey) || '';
-            if (!apiKey && promptIfMissing) {
-                apiKey = prompt('Enter BLT API key', '') || '';
-                if (apiKey) {
-                    localStorage.setItem(apiKeyStorageKey, apiKey);
-                }
-            }
-
-            return apiKey ? { 'X-BLT-API-Key': apiKey } : {};
+            return { 'X-BLT-API-Key': sharedApiKey };
         }
 
         function renderRequestHeaders(headers) {
             const headersEl = document.getElementById('requestHeaders');
+            const noticeEl = document.getElementById('apiKeyNotice');
             const entries = Object.entries(headers);
+            noticeEl.textContent = entries.length
+                ? 'Using the shared BLT API key shown on this page.'
+                : 'No API key is needed for this public endpoint.';
             headersEl.textContent = entries.length
                 ? entries.map(([key, value]) => `${key}: ${value}`).join('\n')
                 : 'No additional headers';
@@ -945,7 +947,7 @@ Authorization: Token YOUR_API_TOKEN</code></pre>
         async function loadSectionCounts() {
             try {
                 const response = await fetch(baseUrl + '/stats', {
-                    headers: getApiKeyHeaders('/stats', false)
+                    headers: getApiKeyHeaders('/stats')
                 });
                 if (!response.ok) throw new Error();
                 const data = await response.json();

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -758,6 +758,36 @@ Authorization: Token YOUR_API_TOKEN</code></pre>
     <!-- JavaScript for API Testing -->
     <script>
         const baseUrl = '[[API_BASE_URL]]';
+        const apiKeyStorageKey = 'bltApiKey';
+        const publicTryItEndpoints = new Set(['/', '/v2', '/health', '/v2/health']);
+
+        function isPublicTryItEndpoint(endpoint) {
+            return publicTryItEndpoints.has(endpoint.split('?')[0]);
+        }
+
+        function getApiKeyHeaders(endpoint, promptIfMissing = true) {
+            if (isPublicTryItEndpoint(endpoint)) {
+                return {};
+            }
+
+            let apiKey = localStorage.getItem(apiKeyStorageKey) || '';
+            if (!apiKey && promptIfMissing) {
+                apiKey = prompt('Enter BLT API key', '') || '';
+                if (apiKey) {
+                    localStorage.setItem(apiKeyStorageKey, apiKey);
+                }
+            }
+
+            return apiKey ? { 'X-BLT-API-Key': apiKey } : {};
+        }
+
+        function renderRequestHeaders(headers) {
+            const headersEl = document.getElementById('requestHeaders');
+            const entries = Object.entries(headers);
+            headersEl.textContent = entries.length
+                ? entries.map(([key, value]) => `${key}: ${value}`).join('\n')
+                : 'No additional headers';
+        }
         
         function closeModal() {
             document.getElementById('apiTestModal').classList.add('hidden');
@@ -787,10 +817,12 @@ Authorization: Token YOUR_API_TOKEN</code></pre>
             }
             
             document.getElementById('requestUrl').textContent = url;
+            const requestHeaders = getApiKeyHeaders(endpoint);
+            renderRequestHeaders(requestHeaders);
             
             // Make request
             const startTime = performance.now();
-            fetch(url)
+            fetch(url, { headers: requestHeaders })
                 .then(response => {
                     const endTime = performance.now();
                     const duration = Math.round(endTime - startTime);
@@ -912,7 +944,9 @@ Authorization: Token YOUR_API_TOKEN</code></pre>
 
         async function loadSectionCounts() {
             try {
-                const response = await fetch(baseUrl + '/stats');
+                const response = await fetch(baseUrl + '/stats', {
+                    headers: getApiKeyHeaders('/stats', false)
+                });
                 if (!response.ok) throw new Error();
                 const data = await response.json();
                 if (data && data.data) {

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -666,18 +666,13 @@
         <section class="bg-white rounded-lg shadow p-6 mb-8">
             <h2 class="text-3xl font-bold text-gray-900 mb-6 text-center">Authentication</h2>
             <div class="max-w-3xl mx-auto">
-                <p class="text-gray-600 text-center mb-4">Protected endpoints require the shared BLT API key. Include it on API requests:</p>
                 <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+                    <p class="text-sm font-semibold text-red-700 mb-2">Shared BLT API key</p>
                     <pre class="text-sm"><code class="text-gray-800">X-BLT-API-Key: f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051</code></pre>
                 </div>
-                <p class="text-gray-600 text-center my-4">Set the same value in the Worker environment:</p>
+                <p class="text-gray-600 text-center my-4">Use this shared key on protected API requests. Try it requests on this page include it automatically.</p>
                 <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
-                    <pre class="text-sm"><code class="text-gray-800">BLT_API_KEY=f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051</code></pre>
-                </div>
-                <p class="text-gray-600 text-center my-4">Routes that also need a signed-in user can include the user token too:</p>
-                <div class="bg-red-50 border border-red-200 rounded-lg p-4">
-                    <pre class="text-sm"><code class="text-gray-800">X-BLT-API-Key: f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051
-Authorization: Token YOUR_API_TOKEN</code></pre>
+                    <pre class="text-sm overflow-x-auto"><code class="text-gray-800">curl -H "X-BLT-API-Key: f5537412b459790f9fa1cc47b862b9c7016471957178dc9b161d59355b6fd051" https://api.owaspblt.org/v2/routes</code></pre>
                 </div>
             </div>
         </section>

--- a/src/utils.py
+++ b/src/utils.py
@@ -11,9 +11,11 @@ import json
 # Falls back to mock implementations for testing
 try:
     from js import Response, Headers, JSON, Object
+    from workers import Response as WorkerResponse
     _WORKERS_RUNTIME = True
 except ImportError:
     _WORKERS_RUNTIME = False
+    WorkerResponse = None
     
     # Mock implementations for testing outside Workers runtime
     class Headers:
@@ -76,11 +78,14 @@ def json_response(
     
     if headers:
         response_headers.update(headers)
+
+    if _WORKERS_RUNTIME and WorkerResponse is not None:
+        return WorkerResponse.json(data, status=status, headers=response_headers)
     
     # Convert Python dict to JSON string
     json_body = json.dumps(data)
     
-    # Create Response with proper status code for Cloudflare Workers
+    # Create Response with proper status code for local tests
     response_init = {
         'status': status,
         'headers': response_headers

--- a/src/utils.py
+++ b/src/utils.py
@@ -23,10 +23,12 @@ except ImportError:
     
     class Response:
         @classmethod
-        def new(cls, body, init=None):
+        def new(cls, body, init=None, **kwargs):
             """Mock Response.new() to match Cloudflare Workers API."""
             if init is None:
-                init = {}
+                init = kwargs
+            elif kwargs:
+                init = {**init, **kwargs}
             return MockResponse(body, init.get('status', 200), init.get('headers', {}))
     
     class MockResponse:
@@ -46,7 +48,7 @@ def cors_headers() -> Dict[str, str]:
     return {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization, X-BLT-API-Key, X-Requested-With",
         "Access-Control-Max-Age": "86400",
     }
 

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 
-from libs.api_key import API_KEY_HEADER, is_api_key_required, validate_api_key_request
+from libs.api_key import API_KEY_HEADER, PUBLIC_BLT_API_KEY, is_api_key_required, validate_api_key_request
 
 
 class MockHeaders(dict):
@@ -96,6 +96,14 @@ def test_valid_api_key_allows_request():
     assert response is None
 
 
+def test_public_static_api_key_allows_request_without_env():
+    request = MockRequest(headers={API_KEY_HEADER: PUBLIC_BLT_API_KEY})
+
+    response = validate_api_key_request(request, EmptyEnv())
+
+    assert response is None
+
+
 def test_api_key_header_is_case_insensitive():
     request = MockRequest(headers={"x-blt-api-key": "docs-static-key"})
 
@@ -113,11 +121,9 @@ def test_plain_dict_api_key_header_is_case_insensitive():
     assert response is None
 
 
-def test_missing_server_api_key_returns_500_for_protected_route():
+def test_env_api_key_remains_accepted_for_local_overrides():
     request = MockRequest(headers={API_KEY_HEADER: "docs-static-key"})
 
-    response = validate_api_key_request(request, EmptyEnv())
+    response = validate_api_key_request(request, MockEnv())
 
-    assert response.status == 500
-    data = _response_data(response)
-    assert data["message"] == "API key authentication is not configured"
+    assert response is None

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,123 @@
+"""
+Tests for shared static API-key validation.
+"""
+
+import json
+
+import pytest
+
+from libs.api_key import API_KEY_HEADER, is_api_key_required, validate_api_key_request
+
+
+class MockHeaders(dict):
+    """Case-insensitive enough header map for tests."""
+
+    def get(self, key, default=None):
+        for existing_key, value in self.items():
+            if existing_key.lower() == key.lower():
+                return value
+        return default
+
+
+class MockRequest:
+    def __init__(self, method="GET", url="https://api.example.com/bugs", headers=None):
+        self.method = method
+        self.url = url
+        self.headers = MockHeaders(headers or {})
+
+
+class MockEnv:
+    BLT_API_KEY = "docs-static-key"
+
+
+class EmptyEnv:
+    pass
+
+
+def _response_data(response):
+    if hasattr(response, "body"):
+        return json.loads(response.body)
+    return response.get("data", {})
+
+
+@pytest.mark.parametrize(
+    ("method", "url"),
+    [
+        ("OPTIONS", "https://api.example.com/bugs"),
+        ("GET", "https://api.example.com"),
+        ("GET", "https://api.example.com/"),
+        ("GET", "https://api.example.com/v2"),
+        ("GET", "https://api.example.com/health"),
+        ("GET", "https://api.example.com/v2/health"),
+    ],
+)
+def test_public_requests_do_not_require_api_key(method, url):
+    assert is_api_key_required(method, url) is False
+    response = validate_api_key_request(MockRequest(method=method, url=url), EmptyEnv())
+    assert response is None
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.example.com/bugs",
+        "https://api.example.com/routes",
+        "https://api.example.com/auth/signin",
+        "https://api.example.com/v2/bugs",
+    ],
+)
+def test_protected_routes_require_api_key(url):
+    assert is_api_key_required("GET", url) is True
+
+
+def test_missing_api_key_returns_401():
+    response = validate_api_key_request(MockRequest(), MockEnv())
+
+    assert response.status == 401
+    data = _response_data(response)
+    assert data["message"] == "Missing API key"
+
+
+def test_invalid_api_key_returns_401():
+    request = MockRequest(headers={API_KEY_HEADER: "wrong-key"})
+
+    response = validate_api_key_request(request, MockEnv())
+
+    assert response.status == 401
+    data = _response_data(response)
+    assert data["message"] == "Invalid API key"
+
+
+def test_valid_api_key_allows_request():
+    request = MockRequest(headers={API_KEY_HEADER: "docs-static-key"})
+
+    response = validate_api_key_request(request, MockEnv())
+
+    assert response is None
+
+
+def test_api_key_header_is_case_insensitive():
+    request = MockRequest(headers={"x-blt-api-key": "docs-static-key"})
+
+    response = validate_api_key_request(request, MockEnv())
+
+    assert response is None
+
+
+def test_plain_dict_api_key_header_is_case_insensitive():
+    request = MockRequest()
+    request.headers = {"x-blt-api-key": "docs-static-key"}
+
+    response = validate_api_key_request(request, MockEnv())
+
+    assert response is None
+
+
+def test_missing_server_api_key_returns_500_for_protected_route():
+    request = MockRequest(headers={API_KEY_HEADER: "docs-static-key"})
+
+    response = validate_api_key_request(request, EmptyEnv())
+
+    assert response.status == 500
+    data = _response_data(response)
+    assert data["message"] == "API key authentication is not configured"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,6 +19,11 @@ class TestBLTClient:
         """Test client initialization with auth token."""
         client = BLTClient("https://api.example.com", auth_token="test-token")
         assert client.auth_token == "test-token"
+
+    def test_client_init_with_api_key(self):
+        """Test client initialization with shared API key."""
+        client = BLTClient("https://api.example.com", api_key="docs-static-key")
+        assert client.api_key == "docs-static-key"
     
     def test_client_base_url_trailing_slash(self):
         """Test that trailing slash is removed from base URL."""
@@ -43,6 +48,25 @@ class TestBLTClient:
         
         assert "Authorization" in headers
         assert headers["Authorization"] == "Token test-token"
+
+    def test_get_headers_with_api_key(self):
+        """Test headers with shared API key."""
+        client = BLTClient("https://api.example.com", api_key="docs-static-key")
+        headers = client._get_headers()
+
+        assert headers["X-BLT-API-Key"] == "docs-static-key"
+
+    def test_get_headers_with_token_and_api_key(self):
+        """Test shared API key does not replace user auth token."""
+        client = BLTClient(
+            "https://api.example.com",
+            auth_token="test-token",
+            api_key="docs-static-key",
+        )
+        headers = client._get_headers()
+
+        assert headers["Authorization"] == "Token test-token"
+        assert headers["X-BLT-API-Key"] == "docs-static-key"
     
     def test_get_headers_extra(self):
         """Test headers with extra headers."""

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -155,3 +155,24 @@ class TestHomepageHandler:
             
             # Check for security: should use textContent, not innerHTML for responses
             assert "textContent = JSON.stringify" in content
+
+    @pytest.mark.asyncio
+    async def test_homepage_try_it_console_sends_api_key_header(self):
+        """Test that Try it requests include the shared API key when needed."""
+        request = MockRequest()
+        env = MockEnv()
+
+        response = await handle_homepage(
+            request,
+            env,
+            path_params={},
+            query_params={},
+            path="/"
+        )
+
+        if hasattr(response, 'body'):
+            content = response.body
+            assert "getApiKeyHeaders" in content
+            assert "localStorage.getItem(apiKeyStorageKey)" in content
+            assert "fetch(url, { headers: requestHeaders })" in content
+            assert "X-BLT-API-Key" in content

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -173,6 +173,7 @@ class TestHomepageHandler:
         if hasattr(response, 'body'):
             content = response.body
             assert "getApiKeyHeaders" in content
-            assert "localStorage.getItem(apiKeyStorageKey)" in content
+            assert "sharedApiKey" in content
             assert "fetch(url, { headers: requestHeaders })" in content
             assert "X-BLT-API-Key" in content
+            assert "prompt('Enter BLT API key'" not in content

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -94,6 +94,25 @@ class TestHomepageHandler:
             # Check for documentation sections
             assert "Response Format" in content or "response format" in content.lower()
             assert "Authentication" in content or "authentication" in content.lower()
+
+    @pytest.mark.asyncio
+    async def test_homepage_documents_static_api_key_header(self):
+        """Test that homepage documents the shared API key header."""
+        request = MockRequest()
+        env = MockEnv()
+
+        response = await handle_homepage(
+            request,
+            env,
+            path_params={},
+            query_params={},
+            path="/"
+        )
+
+        if hasattr(response, 'body'):
+            content = response.body
+            assert "X-BLT-API-Key" in content
+            assert "BLT_API_KEY" in content
     
     @pytest.mark.asyncio
     async def test_homepage_with_custom_url(self):
@@ -136,4 +155,3 @@ class TestHomepageHandler:
             
             # Check for security: should use textContent, not innerHTML for responses
             assert "textContent = JSON.stringify" in content
-

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -112,7 +112,8 @@ class TestHomepageHandler:
         if hasattr(response, 'body'):
             content = response.body
             assert "X-BLT-API-Key" in content
-            assert "BLT_API_KEY" in content
+            assert "BLT_API_KEY" not in content
+            assert "Authorization: Token YOUR_API_TOKEN" not in content
     
     @pytest.mark.asyncio
     async def test_homepage_with_custom_url(self):

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -176,4 +176,6 @@ class TestHomepageHandler:
             assert "sharedApiKey" in content
             assert "fetch(url, { headers: requestHeaders })" in content
             assert "X-BLT-API-Key" in content
+            assert "Try it requests use this shared key automatically." in content
+            assert "Using the shared BLT API key shown on this page." in content
             assert "prompt('Enter BLT API key'" not in content

--- a/tests/test_main_api_key.py
+++ b/tests/test_main_api_key.py
@@ -1,0 +1,138 @@
+"""
+Tests for Worker-level shared API-key enforcement.
+"""
+
+import json
+import importlib
+import sys
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+workers_mod = types.ModuleType("workers")
+
+
+class WorkerEntrypoint:
+    pass
+
+
+class WorkerResponse:
+    @staticmethod
+    def json(data, status=200, headers=None):
+        return {"status": status, "headers": headers or {}, "data": data}
+
+
+workers_mod.WorkerEntrypoint = WorkerEntrypoint
+workers_mod.Response = WorkerResponse
+sys.modules["workers"] = workers_mod
+
+if "main" in sys.modules:
+    main = importlib.reload(sys.modules["main"])
+else:
+    main = importlib.import_module("main")
+
+
+class MockHeaders(dict):
+    def get(self, key, default=None):
+        for existing_key, value in self.items():
+            if existing_key.lower() == key.lower():
+                return value
+        return default
+
+
+class MockRequest:
+    def __init__(self, method="GET", url="https://api.example.com/bugs", headers=None):
+        self.method = method
+        self.url = url
+        self.headers = MockHeaders(headers or {})
+
+
+class MockEnv:
+    BLT_API_KEY = "docs-static-key"
+
+
+def _response_data(response):
+    if hasattr(response, "body"):
+        return json.loads(response.body)
+    return response.get("data", {})
+
+
+@pytest.mark.asyncio
+async def test_on_fetch_rejects_protected_request_without_api_key_before_db():
+    worker = main.Default()
+    worker.env = MockEnv()
+    request = MockRequest(url="https://api.example.com/bugs")
+
+    with patch("main.get_db_safe", AsyncMock()) as get_db, \
+         patch.object(main.router, "handle", AsyncMock()) as handle:
+        response = await worker.on_fetch(request)
+
+    assert response.status == 401
+    assert _response_data(response)["message"] == "Missing API key"
+    get_db.assert_not_called()
+    handle.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_fetch_rejects_protected_request_with_invalid_api_key_before_db():
+    worker = main.Default()
+    worker.env = MockEnv()
+    request = MockRequest(headers={"X-BLT-API-Key": "wrong-key"})
+
+    with patch("main.get_db_safe", AsyncMock()) as get_db, \
+         patch.object(main.router, "handle", AsyncMock()) as handle:
+        response = await worker.on_fetch(request)
+
+    assert response.status == 401
+    assert _response_data(response)["message"] == "Invalid API key"
+    get_db.assert_not_called()
+    handle.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_fetch_allows_protected_request_with_valid_api_key():
+    worker = main.Default()
+    worker.env = MockEnv()
+    request = MockRequest(headers={"X-BLT-API-Key": "docs-static-key"})
+    expected_response = object()
+
+    with patch("main.get_db_safe", AsyncMock()) as get_db, \
+         patch.object(main.router, "handle", AsyncMock(return_value=expected_response)) as handle:
+        response = await worker.on_fetch(request)
+
+    assert response is expected_response
+    get_db.assert_awaited_once_with(worker.env)
+    handle.assert_awaited_once_with(request, worker.env)
+
+
+@pytest.mark.asyncio
+async def test_on_fetch_allows_health_without_api_key():
+    worker = main.Default()
+    worker.env = MockEnv()
+    request = MockRequest(url="https://api.example.com/health")
+    expected_response = object()
+
+    with patch("main.get_db_safe", AsyncMock()) as get_db, \
+         patch.object(main.router, "handle", AsyncMock(return_value=expected_response)) as handle:
+        response = await worker.on_fetch(request)
+
+    assert response is expected_response
+    get_db.assert_awaited_once_with(worker.env)
+    handle.assert_awaited_once_with(request, worker.env)
+
+
+@pytest.mark.asyncio
+async def test_on_fetch_allows_options_preflight_without_api_key():
+    worker = main.Default()
+    worker.env = MockEnv()
+    request = MockRequest(method="OPTIONS", url="https://api.example.com/bugs")
+
+    with patch("main.get_db_safe", AsyncMock()) as get_db, \
+         patch.object(main.router, "handle", AsyncMock()) as handle:
+        response = await worker.on_fetch(request)
+
+    assert response.status == 204
+    get_db.assert_not_called()
+    handle.assert_not_called()

--- a/tests/test_static_api_key_script.py
+++ b/tests/test_static_api_key_script.py
@@ -1,0 +1,91 @@
+"""
+Tests for the static API-key smoke script.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_smoke_script_loads_api_key_from_env_file(tmp_path):
+    """The smoke script should use BLT_API_KEY from an env file when not exported."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("BLT_API_KEY=from-env-file\n", encoding="utf-8")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+
+output_file=""
+api_key=""
+url=""
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output_file="$2"
+      shift 2
+      ;;
+    -H)
+      if [[ "$2" == X-BLT-API-Key:* ]]; then
+        api_key="${2#X-BLT-API-Key: }"
+      fi
+      shift 2
+      ;;
+    -sS)
+      shift
+      ;;
+    -w)
+      shift 2
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ "$url" == */health ]]; then
+  printf '{"status":"healthy"}' > "$output_file"
+  printf '200'
+elif [[ -z "$api_key" ]]; then
+  printf '{"message":"Missing API key"}' > "$output_file"
+  printf '401'
+elif [[ "$api_key" == "from-env-file" ]]; then
+  printf '{"success":true}' > "$output_file"
+  printf '200'
+else
+  printf '{"message":"Invalid API key"}' > "$output_file"
+  printf '401'
+fi
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "API_KEY_ENV_FILE": str(env_file),
+        "BASE_URL": "http://localhost:8787",
+    }
+    env.pop("BLT_API_KEY", None)
+    env.pop("API_KEY", None)
+
+    result = subprocess.run(
+        ["bash", "scripts/test_static_api_key.sh"],
+        cwd=Path(__file__).resolve().parent.parent,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "API key source:" in result.stdout
+    assert "from-env-file" not in result.stdout
+    assert "FAIL" not in result.stdout
+    assert result.stdout.count("PASS expected HTTP") == 4

--- a/tests/test_static_api_key_script.py
+++ b/tests/test_static_api_key_script.py
@@ -6,17 +6,15 @@ import os
 import subprocess
 from pathlib import Path
 
+from libs.api_key import PUBLIC_BLT_API_KEY
 
-def test_smoke_script_loads_api_key_from_env_file(tmp_path):
-    """The smoke script should use BLT_API_KEY from an env file when not exported."""
-    env_file = tmp_path / ".env"
-    env_file.write_text("BLT_API_KEY=from-env-file\n", encoding="utf-8")
 
+def test_smoke_script_uses_public_static_api_key_by_default(tmp_path):
+    """The smoke script should use the public shared API key without local env setup."""
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_curl = fake_bin / "curl"
-    fake_curl.write_text(
-        """#!/usr/bin/env bash
+    fake_curl_source = """#!/usr/bin/env bash
 set -euo pipefail
 
 output_file=""
@@ -54,26 +52,25 @@ if [[ "$url" == */health ]]; then
 elif [[ -z "$api_key" ]]; then
   printf '{"message":"Missing API key"}' > "$output_file"
   printf '401'
-elif [[ "$api_key" == "from-env-file" ]]; then
+elif [[ "$api_key" == "__PUBLIC_BLT_API_KEY__" ]]; then
   printf '{"success":true}' > "$output_file"
   printf '200'
 else
   printf '{"message":"Invalid API key"}' > "$output_file"
   printf '401'
 fi
-""",
-        encoding="utf-8",
-    )
+""".replace("__PUBLIC_BLT_API_KEY__", PUBLIC_BLT_API_KEY)
+    fake_curl.write_text(fake_curl_source, encoding="utf-8")
     fake_curl.chmod(0o755)
 
     env = {
         **os.environ,
         "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
-        "API_KEY_ENV_FILE": str(env_file),
         "BASE_URL": "http://localhost:8787",
     }
     env.pop("BLT_API_KEY", None)
     env.pop("API_KEY", None)
+    env.pop("API_KEY_ENV_FILE", None)
 
     result = subprocess.run(
         ["bash", "scripts/test_static_api_key.sh"],
@@ -85,7 +82,6 @@ fi
     )
 
     assert result.returncode == 0
-    assert "API key source:" in result.stdout
-    assert "from-env-file" not in result.stdout
+    assert f"API key: {PUBLIC_BLT_API_KEY}" in result.stdout
     assert "FAIL" not in result.stdout
     assert result.stdout.count("PASS expected HTTP") == 4

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,6 +40,7 @@ class TestCorsHeaders:
         assert "Access-Control-Allow-Headers" in headers
         assert "Content-Type" in headers["Access-Control-Allow-Headers"]
         assert "Authorization" in headers["Access-Control-Allow-Headers"]
+        assert "X-BLT-API-Key" in headers["Access-Control-Allow-Headers"]
 
 
 class TestPaginationParams:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,10 @@ Tests for the utility functions.
 
 import pytest
 import json
+from unittest.mock import patch
 from src.utils import (
     cors_headers,
+    json_response,
     parse_pagination_params,
 )
 
@@ -41,6 +43,30 @@ class TestCorsHeaders:
         assert "Content-Type" in headers["Access-Control-Allow-Headers"]
         assert "Authorization" in headers["Access-Control-Allow-Headers"]
         assert "X-BLT-API-Key" in headers["Access-Control-Allow-Headers"]
+
+
+class TestJsonResponse:
+    """Tests for JSON response creation."""
+
+    def test_workers_runtime_uses_workers_response_json(self):
+        """Workers runtime should use workers.Response.json for reliable HTTP status."""
+
+        class MockWorkerResponse:
+            calls = []
+
+            @classmethod
+            def json(cls, data, status=200, headers=None):
+                cls.calls.append((data, status, headers))
+                return {"data": data, "status": status, "headers": headers}
+
+        with patch("src.utils._WORKERS_RUNTIME", True), \
+             patch("src.utils.WorkerResponse", MockWorkerResponse):
+            response = json_response({"ok": True}, status=401)
+
+        assert response["status"] == 401
+        assert MockWorkerResponse.calls[0][0] == {"ok": True}
+        assert MockWorkerResponse.calls[0][1] == 401
+        assert "X-BLT-API-Key" in MockWorkerResponse.calls[0][2]["Access-Control-Allow-Headers"]
 
 
 class TestPaginationParams:


### PR DESCRIPTION
fixes #88 

 ## Summary
  - Add shared `X-BLT-API-Key` authentication for protected API routes.
  - Add a public shared API key for docs, homepage Try-it requests, and local smoke testing.
  - Update homepage authentication UI so users can copy the key and Try-it sends it
  automatically.
  - Add a smoke-test script for screenshot-friendly API-key verification.

  ## Test Plan
  - [x] `uv run --extra dev pytest -q`
  - [x] `./scripts/test_static_api_key.sh`
  
  
  ## Screenshot

Working properly for all routes
<img width="678" height="749" alt="image" src="https://github.com/user-attachments/assets/35ec12cb-a899-4ddf-b4db-06fdbba27f6d" />
Auth section
<img width="958" height="272" alt="image" src="https://github.com/user-attachments/assets/4e571f13-e198-4450-a22b-d808170183ec" />

Smoke test

<img width="561" height="323" alt="image" src="https://github.com/user-attachments/assets/bf3dd987-eea7-4432-8a72-954281be9484" />


  
  
  ## Notes
  - Public routes remain accessible without the API key: `/`, `/v2`, `/health`, `/v2/health`,
  and `OPTIONS`.
  - Protected routes return `401` for missing or invalid API keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shared static API key authentication for protected API endpoints, required via the `X-BLT-API-Key` request header.
  * Extended client to support API key authentication alongside token-based auth.

* **Documentation**
  * Updated README and homepage to document static API key requirements and authentication examples.
  * Added `BLT_API_KEY` environment variable configuration.

* **Tests**
  * Added comprehensive test coverage for API key validation, enforcement, and client integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OWASP-BLT/BLT-API/pull/89)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->