### PR TITLE
feat: add API key support

### DIFF
--- a/src/handlers/bugs.py
+++ b/src/handlers/bugs.py
@@ -3,7 +3,7 @@ Bugs handler for the BLT API.
 """
 
 from typing import Any, Dict
-from utils import error_response, parse_pagination_params, parse_json_body, convert_d1_results
+from utils import error_response, parse_pagination_params, parse_json_body, convert_d1_results, require_api_key
 from libs.db import get_db_safe
 from models import Bug
 from workers import Response
@@ -178,6 +178,10 @@ async def handle_bugs(
     
     # Create bug
     if method == "POST":
+        api_key_error = require_api_key(request, env)
+        if api_key_error:
+            return api_key_error
+
         body = await parse_json_body(request)
         
         if not body:

--- a/src/handlers/users.py
+++ b/src/handlers/users.py
@@ -7,7 +7,7 @@ import re
 import secrets
 import time
 from typing import Any, Dict
-from utils import error_response, parse_pagination_params, convert_d1_results, parse_json_body, check_required_fields
+from utils import error_response, parse_pagination_params, convert_d1_results, parse_json_body, check_required_fields, require_api_key
 from libs.db import get_db_safe
 from libs.constant import __HASHING_ITERATIONS
 from libs.data_protection import encrypt_sensitive, decrypt_sensitive, blind_index
@@ -247,6 +247,9 @@ async def handle_users(
             return error_response("Method Not Allowed", status=405, headers={"Allow": "GET"})
 
         if method == "POST":
+            api_key_error = require_api_key(request, env)
+            if api_key_error:
+                return api_key_error
             return await create_user(db, request, env, logger)
 
         # Get specific user

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,6 +6,7 @@ CORS headers, and HTTP client operations.
 """
 
 from typing import Any, Dict, List, Optional
+import hmac
 import json
 # Try to import Cloudflare Workers JS bindings
 # Falls back to mock implementations for testing
@@ -46,7 +47,7 @@ def cors_headers() -> Dict[str, str]:
     return {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization, X-API-Key, X-Requested-With",
         "Access-Control-Max-Age": "86400",
     }
 
@@ -233,6 +234,54 @@ def get_blt_website_url(env: Any) -> str:
         return str(env.BLT_WEBSITE_URL)
     except AttributeError:
         return "https://owaspblt.org"
+
+
+def get_header(request: Any, name: str) -> str:
+    """Read a request header from Workers or test request objects."""
+    headers = getattr(request, "headers", None)
+    if headers and hasattr(headers, "get"):
+        value = headers.get(name)
+        if value is None and name.lower() != name:
+            value = headers.get(name.lower())
+        return str(value) if value is not None else ""
+    return ""
+
+
+def get_configured_api_key(env: Any) -> str:
+    """Return the configured API key, supporting legacy and explicit names."""
+    for name in ("BLT_API_KEY", "API_KEY"):
+        value = getattr(env, name, "")
+        if value:
+            return str(value)
+    return ""
+
+
+def extract_api_key(request: Any) -> str:
+    """Extract an API key from X-API-Key or common Authorization schemes."""
+    api_key = get_header(request, "X-API-Key").strip()
+    if api_key:
+        return api_key
+
+    authorization = get_header(request, "Authorization").strip()
+    if not authorization:
+        return ""
+
+    parts = authorization.split(None, 1)
+    if len(parts) == 2 and parts[0].lower() in {"apikey", "token", "bearer"}:
+        return parts[1].strip()
+    return ""
+
+
+def require_api_key(request: Any, env: Any) -> Optional[Response]:
+    """Validate API key when one is configured; otherwise stay permissive."""
+    expected_key = get_configured_api_key(env)
+    if not expected_key:
+        return None
+
+    provided_key = extract_api_key(request)
+    if not provided_key or not hmac.compare_digest(provided_key, expected_key):
+        return error_response("Invalid or missing API key", status=401)
+    return None
 
 
 async def parse_json_body(request: Any) -> Optional[Dict[str, Any]]:

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -97,9 +97,10 @@ class MockDB:
 
 
 class MockRequest:
-    def __init__(self, method="GET", body=None):
+    def __init__(self, method="GET", body=None, headers=None):
         self.method = method
         self._body = body
+        self.headers = headers or {}
 
     async def text(self):
         if self._body is None:
@@ -111,6 +112,10 @@ class MockRequest:
 
 class MockEnv:
     pass
+
+
+class MockApiKeyEnv:
+    BLT_API_KEY = "secret-key"
 
 
 def _make_mock_bug_class(count=0):
@@ -209,6 +214,38 @@ class TestGetBugById:
 
 
 class TestCreateBug:
+    async def test_configured_api_key_is_required(self):
+        db = MockDB()
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)):
+            resp = await handle_bugs(
+                MockRequest(
+                    method="POST",
+                    body={"url": "https://example.com", "description": "d"},
+                ),
+                MockApiKeyEnv(),
+                {},
+                {},
+                "/bugs",
+            )
+        assert resp.status == 401
+
+    async def test_configured_api_key_allows_create(self):
+        db = MockDB()
+        db.queue_first({"id": 1}, {"id": 1, "url": "https://example.com", "description": "d"})
+        with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)):
+            resp = await handle_bugs(
+                MockRequest(
+                    method="POST",
+                    body={"url": "https://example.com", "description": "d"},
+                    headers={"X-API-Key": "secret-key"},
+                ),
+                MockApiKeyEnv(),
+                {},
+                {},
+                "/bugs",
+            )
+        assert resp.status == 201
+
     async def test_empty_body_returns_400(self):
         db = MockDB()
         with patch("handlers.bugs.get_db_safe", AsyncMock(return_value=db)):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,9 @@ import pytest
 import json
 from src.utils import (
     cors_headers,
+    extract_api_key,
     parse_pagination_params,
+    require_api_key,
 )
 
 
@@ -40,6 +42,45 @@ class TestCorsHeaders:
         assert "Access-Control-Allow-Headers" in headers
         assert "Content-Type" in headers["Access-Control-Allow-Headers"]
         assert "Authorization" in headers["Access-Control-Allow-Headers"]
+        assert "X-API-Key" in headers["Access-Control-Allow-Headers"]
+
+
+class MockRequest:
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+class MockEnv:
+    BLT_API_KEY = "secret-key"
+
+
+class TestApiKeySupport:
+    """Tests for API key extraction and validation."""
+
+    def test_extract_api_key_from_x_api_key(self):
+        request = MockRequest({"X-API-Key": "secret-key"})
+        assert extract_api_key(request) == "secret-key"
+
+    def test_extract_api_key_from_authorization_token(self):
+        request = MockRequest({"Authorization": "Token secret-key"})
+        assert extract_api_key(request) == "secret-key"
+
+    def test_extract_api_key_from_authorization_bearer(self):
+        request = MockRequest({"Authorization": "Bearer secret-key"})
+        assert extract_api_key(request) == "secret-key"
+
+    def test_require_api_key_allows_matching_key(self):
+        request = MockRequest({"X-API-Key": "secret-key"})
+        assert require_api_key(request, MockEnv()) is None
+
+    def test_require_api_key_rejects_missing_key(self):
+        request = MockRequest()
+        response = require_api_key(request, MockEnv())
+        assert response.status == 401
+
+    def test_require_api_key_is_disabled_when_not_configured(self):
+        request = MockRequest()
+        assert require_api_key(request, object()) is None
 
 
 class TestPaginationParams:


### PR DESCRIPTION
## Summary
- add reusable API key extraction/validation helpers
- support `X-API-Key` plus `Authorization: ApiKey`, `Token`, and `Bearer` schemes
- require a configured API key for write endpoints when `BLT_API_KEY` or `API_KEY` is set
- update CORS allowed headers and add tests

## Tests
- `UV_CACHE_DIR=G:\AIgpt\BLT-API\.uv-cache-local uv run --extra dev pytest -q`

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key authentication is now required to create bugs and users. Submit your API key via the `X-API-Key` header or `Authorization` header. Requests without a valid key will receive a 401 response.

* **Tests**
  * Added test coverage for API key authentication enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OWASP-BLT/BLT-API/pull/90)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->